### PR TITLE
Test, Refact, Update#7 auth/profile 테스트 코드 및 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ dependencies {
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'com.google.guava:guava:23.0'
+
 }
 
 // JaCoCo 설정 추가

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.2'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'com.mindmate'
@@ -66,7 +67,41 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+// JaCoCo 설정 추가
+jacocoTestReport {
+	reports {
+		xml.required = true
+		html.required = true
+	}
+
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [
+					"**/dto/**",
+					"**/entity/**"
+			])
+		}))
+	}
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			element = 'CLASS'
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.80
+			}
+			excludes = [
+					'**/dto/**',
+					'**/entity/**'
+			]
+		}
+	}
+}
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
 }

--- a/src/main/java/com/mindmate/mindmate_server/auth/controller/AuthController.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.mindmate.mindmate_server.auth.dto.LoginResponse;
 import com.mindmate.mindmate_server.auth.dto.SignUpRequest;
 import com.mindmate.mindmate_server.auth.dto.TokenResponse;
 import com.mindmate.mindmate_server.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -12,42 +14,49 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "인증", description = "회원가입, 로그인, 이메일 인증 등 인증 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
     private final AuthService authService;
 
+    @Operation(summary = "회원가입", description = "새로운 사용자를 등록하고 인증 메일을 발송합니다.")
     @PostMapping("/register")
     public ResponseEntity<Void> registerUser(@Valid @RequestBody SignUpRequest request) {
         authService.registerUser(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @Operation(summary = "인증 메일 재발송", description = "이메일 인증 메일을 재발송합니다.")
     @PostMapping("/email/resend")
     public ResponseEntity<Void> resendVerificationEmail(@RequestParam String email) {
         authService.resendVerificationEmail(email);
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "이메일 인증", description = "이메일 인증 토큰을 검증합니다.")
     @GetMapping("/email/verify")
     public ResponseEntity<Void> verifyEmail(@RequestParam String token) {
         authService.verifyEmail(token);
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "로그아웃", description = "현재 세션을 종료하고 토큰을 무효화합니다.")
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@RequestHeader("Authorization") String token) {
         authService.logout(token.replace("Bearer ", ""));
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "토큰 갱신", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(
             @RequestHeader("Authorization") String refreshToken,

--- a/src/main/java/com/mindmate/mindmate_server/auth/controller/AuthController.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.mindmate.mindmate_server.auth.dto.TokenResponse;
 import com.mindmate.mindmate_server.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,12 +24,11 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    // 굳이 필요한가 그리고 필요하다면 어떻게 활용할 것인가
-//    @PostMapping("/email/resend")
-//    public ResponseEntity<Void> resendVerificationEmail(@RequestParam String email) {
-//        authService.resendVerificationEmail(email);
-//        return ResponseEntity.ok().build();
-//    }
+    @PostMapping("/email/resend")
+    public ResponseEntity<Void> resendVerificationEmail(@RequestParam String email) {
+        authService.resendVerificationEmail(email);
+        return ResponseEntity.ok().build();
+    }
 
     @GetMapping("/email/verify")
     public ResponseEntity<Void> verifyEmail(@RequestParam String token) {

--- a/src/main/java/com/mindmate/mindmate_server/auth/dto/LoginRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/dto/LoginRequest.java
@@ -10,7 +10,11 @@ import lombok.NoArgsConstructor;
 public class LoginRequest {
     @NotBlank
     private String email;
-
     @NotBlank
     private String password;
+
+    public LoginRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
 }

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/AuthService.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/AuthService.java
@@ -17,4 +17,6 @@ public interface AuthService {
     void logout(String bearer);
 
     TokenResponse refresh(String bearer, String bearer1);
+
+    void resendVerificationEmail(String email);
 }

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/AuthServiceImpl.java
@@ -34,7 +34,7 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordValidator passwordValidator;
 
     private final RedisTemplate<String, String> redisTemplate;
-    private static final long RESEND_LIMIT_MINUTES = 5;
+    public static final long RESEND_LIMIT_MINUTES = 5;
 
     private final PasswordEncoder passwordEncoder;
 

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/AuthServiceImpl.java
@@ -9,12 +9,16 @@ import com.mindmate.mindmate_server.user.domain.RoleType;
 import com.mindmate.mindmate_server.user.domain.User;
 import com.mindmate.mindmate_server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static com.mindmate.mindmate_server.auth.service.LoginAttemptService.MAX_ATTEMPTS;
 
@@ -29,8 +33,17 @@ public class AuthServiceImpl implements AuthService {
     private final LoginAttemptService loginAttemptService;
     private final PasswordValidator passwordValidator;
 
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final long RESEND_LIMIT_MINUTES = 5;
+
     private final PasswordEncoder passwordEncoder;
 
+    /**
+     * 회원가입
+     * 1. 이미 등록된 이메일인지 확인
+     * 2. 비밀번호 암호화 및 1차 - 2차 비밀번호 동일한지 확인
+     * 3. 사용자 저장 및 이메일 보내기
+     */
     @Override
     public void registerUser(SignUpRequest request) {
         if (userService.existsByEmail(request.getEmail())) {
@@ -49,24 +62,55 @@ public class AuthServiceImpl implements AuthService {
         user.generateVerificationToken();
 
         userService.save(user);
-        emailService.sendVerificationEmail(user, user.getVerificationToken(), "init");
+        emailService.sendVerificationEmail(user, user.getVerificationToken());
     }
 
-//    public void resendVerificationEmail(String email) {
-//        User user = userService.findByEmail(email);
-//
-//        if (user.isEmailVerified()) {
-//            throw new CustomException(AuthErrorCode.EMAIL_ALREADY_VERIFIED);
-//        }
-//
-//        user.generateVerificationToken();
-//        userService.save(user);
-//        emailService.sendVerificationEmail(user, user.getVerificationToken(), "resend");
-//    }
+    /**
+     * 이메일 재전송
+     * 1. 해당 이메일이 등록된 상태인지
+     * 2. 해당 이메일이 이미 인증됐는지
+     * 3. redis를 이용해서 5분 이후에 재전송 가능하게 설정
+     */
+    @Override
+    public void resendVerificationEmail(String email) {
+        User user = userService.findByEmail(email);
 
+        if (user.isEmailVerified()) {
+            throw new CustomException(AuthErrorCode.EMAIL_ALREADY_VERIFIED);
+        }
+        
+        String redisKey = "email-resend" + email;
+        String lastRequestTime = redisTemplate.opsForValue().get(redisKey);
+        
+        if (lastRequestTime != null) {
+            LocalDateTime lastRequest = LocalDateTime.parse(lastRequestTime);
+            if (Duration.between(lastRequest, LocalDateTime.now()).toMinutes() < RESEND_LIMIT_MINUTES) {
+                throw new CustomException(AuthErrorCode.RESEND_TOO_FREQUENTLY);
+            }
+        }
+
+        user.generateVerificationToken();
+        userService.save(user);
+        emailService.sendVerificationEmail(user, user.getVerificationToken());
+        
+        // ttl 적용해서 자동 만료되도록 설정
+        redisTemplate.opsForValue().set(redisKey, LocalDateTime.now().toString(), RESEND_LIMIT_MINUTES, TimeUnit.MINUTES);
+    }
+
+    /**
+     * 이메일 인증
+     * 1. 사용자가 가진 이메일 토큰이 만료됐는지 확인 + 이전 토큰은 무효화(재전송 고려)
+     * 2. 정상적이면 인증 완료 처리
+     * 3. UNAUTHORIZED -> USER로 role 변환
+     * 현재 방식은 이전 토큰은 무효화하고 새로 생성된 토큰만 유효
+     */
     @Override
     public void verifyEmail(String token) {
         User user = userService.findVerificationToken(token);
+
+        if (user == null || !user.getVerificationToken().equals(token)) {
+            throw new CustomException(AuthErrorCode.INVALID_TOKEN);
+        }
 
         if (user.isTokenExpired()) {
             throw new CustomException(AuthErrorCode.VERIFICATION_TOKEN_EXPIRED);
@@ -132,6 +176,11 @@ public class AuthServiceImpl implements AuthService {
                 .build();
     }
 
+    /**
+     * 로그아웃
+     * 액세스 토큰 블랙리스트 처리
+     * 리프레시 토큰 삭제
+     */
     @Override
     public void logout(String token) {
         tokenService.addToBlackList(token);

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/AuthServiceImpl.java
@@ -39,9 +39,9 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
 
     /**
-     * 회원가입
-     * 1. 이미 등록된 이메일인지 확인
-     * 2. 비밀번호 암호화 및 1차 - 2차 비밀번호 동일한지 확인
+     * 회원가입<p>
+     * 1. 이미 등록된 이메일인지 확인<br>
+     * 2. 비밀번호 암호화 및 1차 - 2차 비밀번호 동일한지 확인<br>
      * 3. 사용자 저장 및 이메일 보내기
      */
     @Override

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/EmailService.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/EmailService.java
@@ -16,12 +16,15 @@ import org.springframework.stereotype.Service;
 public class EmailService {
     private final JavaMailSender mailSender;
 
-    private static final long RESEND_DELAY_MINUTES = 5;
+    /**
+     * 인증 이메일 보내기
+     * 비동기로 처리하여 실제로 바로 메일을 확인 못하더라도 사용자 경험 향상
+     */
 
     @Async
-    public void sendVerificationEmail(User user, String token, String type) {
+    public void sendVerificationEmail(User user, String token) {
         String subject = "이메일 인증을 완료해주세요";
-        String content = getString(token, type);
+        String content = getString(token);
         MimeMessage message = mailSender.createMimeMessage();
 
         try {
@@ -35,18 +38,15 @@ public class EmailService {
         }
     }
 
-    private static String getString(String token, String type) {
+    private static String getString(String token) {
         String verificationLink = "http://localhost:8080/api/auth/email/verify?token=" + token;
-//        String verificationLink = type.equals("init") ? "http://localhost:8080/api/auth/email/verify?token=" + token
-//                : "http://localhost:8080/api/auth/email-verification/resend?token=" + token;
 
-        String content = String.format(
+        return String.format(
                     "아래 링크를 클릭하여 이메일 인증을 완료해주세요:<br>"
                     + "<a href='%s'>이메일 인증하기</a><br>"
                     + "이 링크는 24시간 동안 유효합니다.",
                 verificationLink
         );
-        return content;
     }
 
     /**

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/LoginAttemptService.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/LoginAttemptService.java
@@ -19,6 +19,10 @@ public class LoginAttemptService {
     private static final String ATTEMPTS_PREFIX = "login-attempts:";
     private static final String LOCKED_PREFIX = "login-locked:";
 
+    /**
+     * 로그인 실패 처리
+     * redis로 시도 횟수 관리
+     */
     public void loginFailed(String email) {
         String attemptKey = ATTEMPTS_PREFIX + email;
         String lockedKey = LOCKED_PREFIX + email;
@@ -46,6 +50,10 @@ public class LoginAttemptService {
         log.info("Failed login attempt {} for email: {}", currentAttempts, email);
     }
 
+    /**
+     * 로그인 성공
+     * 시도 횟수, 잠금 키 제거
+     */
     public void loginSucceeded(String email) {
         String attemptsKey = ATTEMPTS_PREFIX + email;
         String lockedKey = LOCKED_PREFIX + email;

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/TokenService.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/TokenService.java
@@ -49,9 +49,9 @@ public class TokenService {
         }
     }
 
-    public void invalidateTokenFamily(String tokenFamily) {
-        redisTemplate.delete(TOKEN_FAMILY_PREFIX + tokenFamily);
-    }
+//    public void invalidateTokenFamily(String tokenFamily) {
+//        redisTemplate.delete(TOKEN_FAMILY_PREFIX + tokenFamily);
+//    }
 
     public void invalidateRefreshToken(Long userId) {
         redisTemplate.delete(REFRESH_TOKEN_PREFIX + userId);

--- a/src/main/java/com/mindmate/mindmate_server/auth/util/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/util/JwtAuthenticationFilter.java
@@ -30,6 +30,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final UserService userService;
     private final TokenService tokenService;
 
+    /**
+     * 모든 요청에 대해 JWT 토큰 검증
+     * - 토큰 유효성, 블랙리스트 확인
+     * - SecurityContext에 인증 정보 설정 -> SecurityUtil로 사용자 정보 얻어내기
+     */
     @Override
     protected void doFilterInternal(
             HttpServletRequest request,

--- a/src/main/java/com/mindmate/mindmate_server/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/util/JwtTokenProvider.java
@@ -48,14 +48,12 @@ public class JwtTokenProvider {
 
     /**
      * 액세스 토큰 생성
-     * (id, roles, username, tokenType)
-     *
-     * admin일 때 username 어떻게 처리할 지 해결못함
+     * (id, role, username, tokenType)
+     * 이후 요청마다 헤어(Authorization: Bearer <token>에 JWT 포함하여 전달
      */
     public String generateToken(User user) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + jwtExpiration);
-
 
         String username = switch (user.getCurrentRole()) {
             case ROLE_UNVERIFIED, ROLE_USER -> user.getEmail();
@@ -68,7 +66,6 @@ public class JwtTokenProvider {
                 .subject(String.valueOf(user.getId()))
                 .claim("role", user.getCurrentRole().name())
                 .claim("username", username)
-//                .claim("isProfileComplete", isProfileComplete(user))
                 .claim("tokenType", "ACCESS")
                 .issuedAt(now)
                 .expiration(expiryDate)
@@ -80,6 +77,9 @@ public class JwtTokenProvider {
         return user.getCurrentRole() != RoleType.ROLE_UNVERIFIED && user.getCurrentRole() != RoleType.ROLE_USER;
     }
 
+    /**
+     * 변조 방지
+     */
     private SecretKey getSigningKey() {
         byte[] keyBytes = Base64.getDecoder().decode(jwtSecret);
         return Keys.hmacShaKeyFor(keyBytes);

--- a/src/main/java/com/mindmate/mindmate_server/auth/util/PasswordValidator.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/util/PasswordValidator.java
@@ -6,6 +6,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class PasswordValidator {
+    /**
+     * 길이: 8 ~ 20
+     * 대문자, 소문자, 숫자, 특수문자 반드시 포함
+     */
     public void validatePassword(String password) {
         if (password.length() < 8 || password.length() > 20) {
             throw new CustomException(AuthErrorCode.INVALID_PASSWORD_FORMAT);

--- a/src/main/java/com/mindmate/mindmate_server/auth/util/SecurityUtil.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/util/SecurityUtil.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class SecurityUtil {
+    /**
+     * SecurityContext로부터 현재 사용자 식별
+     */
     public static User getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {

--- a/src/main/java/com/mindmate/mindmate_server/auth/util/SecurityUtil.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/util/SecurityUtil.java
@@ -12,7 +12,7 @@ public class SecurityUtil {
     /**
      * SecurityContext로부터 현재 사용자 식별
      */
-    public static User getCurrentUser() {
+    public User getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
             throw new CustomException(AuthErrorCode.UNAUTHORIZED);

--- a/src/main/java/com/mindmate/mindmate_server/global/config/AsyncConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/AsyncConfig.java
@@ -1,0 +1,10 @@
+package com.mindmate.mindmate_server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+}

--- a/src/main/java/com/mindmate/mindmate_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/SecurityConfig.java
@@ -63,10 +63,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers(
                             "/api/**",
-                            "/api/auth/register",
-                            "/api/auth/login",
-                            "/api/auth/verify-email",
-                            "/api/auth/resend-verification",
+//                            "/api/auth/register",
+//                            "/api/auth/login",
+//                            "/api/auth/verify-email",
+//                            "/api/auth/resend-verification",
                             "/swagger-ui/**",
                             "/swagger-resources/**",
                             "/v3/api-docs/**"

--- a/src/main/java/com/mindmate/mindmate_server/global/exception/AuthErrorCode.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/exception/AuthErrorCode.java
@@ -26,6 +26,7 @@ public enum AuthErrorCode implements ErrorCode {
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송을 실패하였습니다"),
     EMAIL_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다"),
     EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 필요합니다"),
+    RESEND_TOO_FREQUENTLY(HttpStatus.TOO_MANY_REQUESTS, "이메일 재전송 요청이 너무 많습니다. 5분 뒤에 시도해주세요" ),
 
     // 로그인
     ACCOUNT_LOCKED(HttpStatus.TOO_MANY_REQUESTS, "계정이 잠겼습니다. 잠금 해제까지 남은 시간: %s분"),

--- a/src/main/java/com/mindmate/mindmate_server/global/exception/ProfileErrorCode.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/exception/ProfileErrorCode.java
@@ -10,7 +10,9 @@ public enum ProfileErrorCode implements ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     INVALID_AVAILABLE_TIME(HttpStatus.BAD_REQUEST, "상담 가능 시간이 올바르지 않습니다."),
     SAME_ROLE_TRANSITION(HttpStatus.BAD_REQUEST, "현재 역할과 동일한 역할로 전환할 수 없습니다."),
-    INVALID_ROLE_TRANSITION(HttpStatus.BAD_REQUEST, "잘못된 역할 전환입니다.");
+    INVALID_ROLE_TRANSITION(HttpStatus.BAD_REQUEST, "잘못된 역할 전환입니다."),
+    PROFILE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 해당 프로필 정보가 등록되었습니다." ), 
+    INVALID_ROLE_TYPE(HttpStatus.BAD_REQUEST, "잘못된 역할입니다." );
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/mindmate/mindmate_server/user/controller/ProfileController.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/controller/ProfileController.java
@@ -5,6 +5,8 @@ import com.mindmate.mindmate_server.user.domain.CounselingStyle;
 import com.mindmate.mindmate_server.user.domain.RoleType;
 import com.mindmate.mindmate_server.user.dto.*;
 import com.mindmate.mindmate_server.user.service.ProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,29 +16,35 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Tag(name = "프로필", description = "스피커/리스너 프로필 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/profile")
 public class ProfileController {
     private final ProfileService profileService;
+
+    @Operation(summary = "리스너 프로필 생성", description = "리스너 프로필을 생성합니다.")
     @PostMapping("/listener")
     public ResponseEntity<ProfileResponse> createListenerProfile(@Valid @RequestBody ListenerProfileRequest request) {
         ProfileResponse response = profileService.createListenerProfile(request);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "스피커 프로필 생성", description = "스피커 프로필을 생성합니다.")
     @PostMapping("/speaker")
     public ResponseEntity<ProfileResponse> createSpeakerProfile(@Valid @RequestBody SpeakerProfileRequest request) {
         ProfileResponse response = profileService.createSpeakerProfile(request);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "역할 전환", description = "리스너/스피커 역할을 전환합니다.")
     @PostMapping("/switch-role")
     public ResponseEntity<?> switchRole(@RequestParam RoleType targetRole) {
         ProfileStatusResponse response = profileService.switchRole(targetRole);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "상담 스타일 목록 조회", description = "가능한 상담 스타일 목록을 조회합니다.")
     @GetMapping("/counseling-styles")
     public ResponseEntity<List<CounselingResponse>> getCounselingStyles() {
         return ResponseEntity.ok(Arrays.stream(CounselingStyle.values())
@@ -44,11 +52,11 @@ public class ProfileController {
                 .collect(Collectors.toList()));
     }
 
+    @Operation(summary = "상담 분야 목록 조회", description = "가능한 상담 분야 목록을 조회합니다.")
     @GetMapping("/counseling-fields")
     public ResponseEntity<List<CounselingResponse>> getCounselingField() {
         return ResponseEntity.ok(Arrays.stream(CounselingField.values())
                 .map(field -> new CounselingResponse(field.getTitle()))
                 .collect(Collectors.toList()));
     }
-
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/ListenerProfile.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/ListenerProfile.java
@@ -47,9 +47,10 @@ public class ListenerProfile extends BaseTimeEntity {
     private User user;
 
     @Builder
-    public ListenerProfile(User user, String nickname, CounselingStyle counselingStyle, LocalDateTime availableTime) {
+    public ListenerProfile(User user, String nickname, String profileImage, CounselingStyle counselingStyle, LocalDateTime availableTime) {
         this.user = user;
         this.nickname = nickname;
+        this.profileImage = profileImage;
         this.counselingStyle = counselingStyle;
         this.availableTime = availableTime;
     }

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/SpeakerProfile.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/SpeakerProfile.java
@@ -32,9 +32,10 @@ public class SpeakerProfile extends BaseTimeEntity {
     private User user;
 
     @Builder
-    public SpeakerProfile(User user, String nickname, CounselingStyle preferredCounselingStyle) {
+    public SpeakerProfile(User user, String nickname, String profileImage, CounselingStyle preferredCounselingStyle) {
         this.user = user;
         this.nickname = nickname;
+        this.profileImage = profileImage;
         this.preferredCounselingStyle = preferredCounselingStyle;
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.mindmate.mindmate_server.user.domain;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -78,5 +79,16 @@ public class User extends BaseTimeEntity {
 
     public boolean isTokenExpired() {
         return this.getVerificationTokenExpiry().isBefore(LocalDateTime.now());
+    }
+
+
+    @VisibleForTesting
+    public void setListenerProfileForTest(ListenerProfile profile) {
+        this.listenerProfile = profile;
+    }
+
+    @VisibleForTesting
+    public void setSpeakerProfileForTest(SpeakerProfile profile) {
+        this.speakerProfile = profile;
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/dto/ProfileResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/dto/ProfileResponse.java
@@ -11,4 +11,13 @@ public class ProfileResponse {
     private String nickname;
     private RoleType role;
     private String message;
+
+    public static ProfileResponse of(Long id, String nickname, RoleType role, String message) {
+        return ProfileResponse.builder()
+                .id(id)
+                .nickname(nickname)
+                .role(role)
+                .message(message)
+                .build();
+    }
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/dto/ProfileStatusResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/dto/ProfileStatusResponse.java
@@ -12,4 +12,15 @@ public class ProfileStatusResponse {
     private RoleType currentRole;
     private boolean hasListenerProfile;
     private boolean hasSpeakerProfile;
+
+    public static ProfileStatusResponse of(String status, String message, RoleType currentRole,
+                                           boolean hasListenerProfile, boolean hasSpeakerProfile) {
+        return ProfileStatusResponse.builder()
+                .status(status)
+                .message(message)
+                .currentRole(currentRole)
+                .hasListenerProfile(hasListenerProfile)
+                .hasSpeakerProfile(hasSpeakerProfile)
+                .build();
+    }
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/service/ProfileServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/ProfileServiceImpl.java
@@ -50,7 +50,7 @@ public class ProfileServiceImpl implements ProfileService {
         User user = getCurrentUser();
         SpeakerProfile profile = createSpeakerProfileFromRequest(user, request);
 
-        return saveProfileAndUpdateRole(profile, RoleType.ROLE_LISTENER);
+        return saveProfileAndUpdateRole(profile, RoleType.ROLE_SPEAKER);
     }
 
     /**

--- a/src/test/java/com/mindmate/mindmate_server/auth/AuthServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/AuthServiceTest.java
@@ -1,0 +1,523 @@
+package com.mindmate.mindmate_server.auth;
+
+import com.mindmate.mindmate_server.auth.dto.*;
+import com.mindmate.mindmate_server.auth.service.AuthServiceImpl;
+import com.mindmate.mindmate_server.auth.service.EmailService;
+import com.mindmate.mindmate_server.auth.service.LoginAttemptService;
+import com.mindmate.mindmate_server.auth.service.TokenService;
+import com.mindmate.mindmate_server.auth.util.JwtTokenProvider;
+import com.mindmate.mindmate_server.auth.util.PasswordValidator;
+import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static com.mindmate.mindmate_server.auth.service.AuthServiceImpl.RESEND_LIMIT_MINUTES;
+import static com.mindmate.mindmate_server.auth.service.LoginAttemptService.MAX_ATTEMPTS;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+    @Mock private UserService userService;
+    @Mock private TokenService tokenService;
+    @Mock private EmailService emailService;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private LoginAttemptService loginAttemptService;
+    @Mock private PasswordValidator passwordValidator;
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+    @Mock private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Nested
+    @DisplayName("회원가입 테스트")
+    class RegisterUserTest {
+
+        @Test
+        @DisplayName("정상적인 회원가입 성공")
+        void registerUser_Success() {
+            // given
+            SignUpRequest request = new SignUpRequest("test@email.com", "password123", "password123");
+            when(userService.existsByEmail(anyString())).thenReturn(false);
+            when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+
+            // when
+            authService.registerUser(request);
+
+            // then
+            verify(userService).existsByEmail(request.getEmail());
+            verify(passwordValidator).validatePassword(request.getPassword());
+            verify(userService).save(any(User.class));
+            verify(emailService).sendVerificationEmail(any(User.class), anyString());
+        }
+
+        @Test
+        @DisplayName("중복 이메일")
+        void registerUser_DuplicateEmail() {
+            // given
+            SignUpRequest request = new SignUpRequest("test@email.com", "password123", "password123");
+            when(userService.existsByEmail(anyString())).thenReturn(true);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.registerUser(request));
+            verify(userService).existsByEmail(request.getEmail());
+        }
+
+        @Test
+        @DisplayName("비밀번호 검증 실패")
+        void registerUser_PasswordMismatch() {
+            // given
+            SignUpRequest request = new SignUpRequest("test@email.com", "password123", "password456");
+            doThrow(new CustomException(AuthErrorCode.PASSWORD_MISMATCH))
+                    .when(passwordValidator)
+                    .validatePasswordMatch(request.getPassword(), request.getConfirmPassword());
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.registerUser(request));
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일 재전송")
+    class ResendVerificationEmail {
+        @Test
+        @DisplayName("정상 재전송")
+        void resendVerificationEmail_Success() {
+            // given
+            String email = "test@email.com";
+            String verificationToken = "test-token";
+            User user = mock(User.class);
+
+            when(userService.findByEmail(email)).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(false);
+            when(user.getVerificationToken()).thenReturn(verificationToken);
+            when(valueOperations.get(anyString())).thenReturn(null);
+
+            // when
+            authService.resendVerificationEmail(email);
+
+            // then
+            verify(user).getVerificationToken();
+            verify(userService).save(user);
+            verify(emailService).sendVerificationEmail(eq(user), eq(verificationToken));
+        }
+
+        @Test
+        @DisplayName("이미 인증된 이메일")
+        void resendVerificationEmail_AlreadyVerified() {
+            // given
+            String email = "test@email.com";
+            User user = mock(User.class);
+
+            when(userService.findByEmail(email)).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(true);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.resendVerificationEmail(email));
+        }
+
+        @Test
+        @DisplayName("재전송 제한 시간")
+        void resendVerificationEmail_TooFrequent() {
+            // given
+            String email = "test@email.com";
+            User user = mock(User.class);
+
+            when(userService.findByEmail(email)).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(false);
+            when(valueOperations.get(anyString()))
+                    .thenReturn(LocalDateTime.now().toString());
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.resendVerificationEmail(email));
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일 인증 테스트")
+    class VerifyEmailTest {
+        @Test
+        @DisplayName("정상적인 이메일 인증 성공")
+        void verifyEmail_Success() {
+            // given
+            String token = "valid-token";
+            User user = mock(User.class);
+
+            when(userService.findVerificationToken(token)).thenReturn(user);
+            when(user.getVerificationToken()).thenReturn(token);
+            when(user.isTokenExpired()).thenReturn(false);
+
+            // when
+            authService.verifyEmail(token);
+
+            // then
+            verify(userService).findVerificationToken(token);
+            verify(user).verifyEmail();
+            verify(user).updateRole(RoleType.ROLE_USER);
+            verify(userService).save(user);
+        }
+
+        @Test
+        @DisplayName("잘못된 토큰으로 인증 시도")
+        void verifyEmail_InvalidToken() {
+            // given
+            String token = "invalid-token";
+            when(userService.findVerificationToken(token)).thenReturn(null);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.verifyEmail(token));
+        }
+
+        @Test
+        @DisplayName("만료된 토큰으로 인증 시도")
+        void verifyEmail_ExpiredToken() {
+            // given
+            String token = "expired-token";
+            User user = mock(User.class);
+
+            when(userService.findVerificationToken(token)).thenReturn(user);
+            when(user.getVerificationToken()).thenReturn(token);
+            when(user.isTokenExpired()).thenReturn(true);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.verifyEmail(token));
+        }
+
+        @Test
+        @DisplayName("재전송 제한 시간 초과하지 않은 경우")
+        void resendVerificationEmail_TooFrequent() {
+            // given
+            String email = "test@email.com";
+            User user = mock(User.class);
+
+            LocalDateTime recentRequestTime = LocalDateTime.now().minusMinutes(RESEND_LIMIT_MINUTES - 1);
+            when(userService.findByEmail(email)).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(false);
+
+            when(valueOperations.get(anyString())).thenReturn(recentRequestTime.toString());
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.resendVerificationEmail(email));
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인")
+    class Login {
+        @Test
+        @DisplayName("정상 로그인")
+        void login_Success() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "password123");
+            User user = mock(User.class);
+
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
+            when(userService.findByEmail(request.getEmail())).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(true);
+            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(true);
+
+            String accessToken = "access-token";
+            String refreshToken = "refresh-token";
+
+            when(jwtTokenProvider.generateToken(any(User.class))).thenReturn(accessToken);
+            when(jwtTokenProvider.generateRefreshToken(any(User.class), anyString())).thenReturn(refreshToken);
+
+            // when
+            LoginResponse response = authService.login(request);
+
+            // then
+            assertNotNull(response);
+            assertEquals(accessToken, response.getAccessToken());
+            assertEquals(refreshToken, response.getRefreshToken());
+
+            verify(loginAttemptService).loginSucceeded(request.getEmail());
+        }
+
+        @Test
+        @DisplayName("계정 잠금 상태에서 로그인 시도")
+        void login_AccountLocked() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "password123");
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(true);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.login(request));
+        }
+
+        @Test
+        @DisplayName("이메일 미인증 상태에서 로그인 시도")
+        void login_EmailNotVerified() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "password123");
+            User user = mock(User.class);
+
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
+            when(userService.findByEmail(request.getEmail())).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(false);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.login(request));
+        }
+
+        @Test
+        @DisplayName("비밀번호 불일치 로그인 실패")
+        void login_PasswordMismatch() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "wrong-password");
+            User user = mock(User.class);
+
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
+            when(userService.findByEmail(request.getEmail())).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(true);
+            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(false);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.login(request));
+            verify(loginAttemptService).loginFailed(request.getEmail());
+        }
+
+        @Test
+        @DisplayName("프로필 작성이 필요한 경우 메시지 반환")
+        void login_ProfileMessageNeeded() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "password123");
+            User user = mock(User.class);
+
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
+            when(userService.findByEmail(request.getEmail())).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(true);
+            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(true);
+            when(user.getCurrentRole()).thenReturn(RoleType.ROLE_USER);
+
+            String accessToken = "access-token";
+            String refreshToken = "refresh-token";
+
+            when(jwtTokenProvider.generateToken(user)).thenReturn(accessToken);
+            when(jwtTokenProvider.generateRefreshToken(eq(user), anyString())).thenReturn(refreshToken);
+
+            // when
+            LoginResponse response = authService.login(request);
+
+            // then
+            assertNotNull(response);
+            assertEquals("프로필 작성이 필요합니다.", response.getMessage());
+        }
+
+        @Test
+        @DisplayName("로그인 시도가 횟수 남지 않아 계정이 잠긴 경우")
+        void login_AccountLockedAfterMaxAttempts() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "wrong-password");
+            User user = mock(User.class);
+
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
+            when(userService.findByEmail(request.getEmail())).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(true);
+            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(false);
+            when(loginAttemptService.getCurrentAttempts(request.getEmail())).thenReturn(MAX_ATTEMPTS);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> authService.login(request));
+
+            assertEquals(AuthErrorCode.ACCOUNT_LOCKED, exception.getErrorCode());;
+            Map<String, Object> details = (Map<String, Object>) exception.getDetails();
+            assertNotNull(details);
+            assertEquals(0, details.get("remainingAttempts"));
+
+            verify(loginAttemptService).loginFailed(request.getEmail());
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃 테스트")
+    class LogoutTest {
+        @Test
+        @DisplayName("정상적인 로그아웃 성공")
+        void logout_Success() {
+            // given
+            String token = "valid-access-token";
+            Long userId = 1L;
+
+            when(jwtTokenProvider.getUserIdFromToken(token)).thenReturn(userId);
+
+            // when
+            authService.logout(token);
+
+            // then
+            verify(tokenService).addToBlackList(token);
+            verify(tokenService).invalidateRefreshToken(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 갱신 테스트")
+    class RefreshTest {
+        @Test
+        @DisplayName("정상적인 토큰 갱신 성공")
+        void refresh_Success() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            String accessToken = "old-access-token";
+
+            Long userId = 1L;
+            User user = mock(User.class);
+            TokenData tokenData = TokenData.of(refreshToken, "token-family");
+
+            String newAccessToken = "new-access-token";
+            String newRefreshToken = "new-refresh-token";
+
+            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
+            when(jwtTokenProvider.getTokenTypeFromToken(refreshToken)).thenReturn("REFRESH");
+            when(userService.findUserById(userId)).thenReturn(user);
+            when(jwtTokenProvider.getTokenFamilyFromToken(refreshToken)).thenReturn("token-family");
+            when(tokenService.getRefreshToken(userId)).thenReturn(tokenData);
+
+            when(jwtTokenProvider.generateToken(user)).thenReturn(newAccessToken);
+            when(jwtTokenProvider.generateRefreshToken(eq(user), anyString())).thenReturn(newRefreshToken);
+
+            // when
+            TokenResponse response = authService.refresh(refreshToken, accessToken);
+
+            // then
+            assertNotNull(response);
+            assertEquals(newAccessToken, response.getAccessToken());
+            assertEquals(newRefreshToken, response.getRefreshToken());
+
+            verify(tokenService).addToBlackList(refreshToken);
+            verify(tokenService).saveRefreshToken(eq(userId), eq(newRefreshToken), anyString());
+        }
+
+        @Test
+        @DisplayName("리프레시 토큰 재사용 감지")
+        void refresh_TokenReuseDetected() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            Long userId = 1L;
+
+//            TokenData tokenData = null;
+
+            setupRefreshMocks(refreshToken, userId, null);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
+            verify(tokenService).invalidateRefreshToken(userId);
+        }
+
+        @Test
+        @DisplayName("저장된 토큰 데이터가 null인 경우 예외 발생")
+        void refresh_StoredTokenDataNull() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            Long userId = 1L;
+
+            setupRefreshMocks(refreshToken, userId, null);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
+        }
+
+        @Test
+        @DisplayName("토큰 패밀리가 일치하지 않는 경우 예외 발생")
+        void refresh_TokenFamilyMismatch() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            Long userId = 1L;
+            TokenData tokenData = TokenData.of("refresh-token", "different-family");
+
+            setupRefreshMocks(refreshToken, userId, tokenData);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 리프레시 토큰으로 예외 발생")
+        void refresh_InvalidRefreshToken() {
+            // given
+            String refreshToken = "invalid-refresh-token";
+            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(false);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
+        }
+
+        @Test
+        @DisplayName("리프레시 토큰 타입이 올바르지 않은 경우")
+        void refresh_InvalidTokenType() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(jwtTokenProvider.getTokenTypeFromToken(refreshToken)).thenReturn("ACCESS");
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
+        }
+
+        @Test
+        @DisplayName("유효한 액세스 토큰이 블랙리스트에 추가되는 경우")
+        void refresh_AccessTokenBlacklisted() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            String accessToken = "valid-access-token";
+            Long userId = 1L;
+            User user = mock(User.class);
+
+            TokenData tokenData = TokenData.of(refreshToken, "token-family");
+
+            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(jwtTokenProvider.validateToken(accessToken)).thenReturn(true);
+            when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
+            when(userService.findUserById(userId)).thenReturn(user);
+
+            setupRefreshMocks(refreshToken, userId, tokenData);
+
+            String newAccessToken = "new-access-token";
+            String newRefreshToken = "new-refresh-token";
+
+            when(jwtTokenProvider.generateRefreshToken(eq(user), anyString())).thenReturn(newRefreshToken);
+            when(jwtTokenProvider.generateToken(eq(user))).thenReturn(newAccessToken);
+
+            // when
+            TokenResponse response = authService.refresh(refreshToken, accessToken);
+
+            // then
+            verify(tokenService).addToBlackList(accessToken);
+        }
+
+    }
+
+    private void setupRefreshMocks(String refreshToken, Long userId, TokenData tokenData) {
+        when(jwtTokenProvider.getTokenTypeFromToken(refreshToken)).thenReturn("REFRESH");
+        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
+        when(jwtTokenProvider.getTokenFamilyFromToken(refreshToken)).thenReturn("token-family");
+        when(tokenService.getRefreshToken(userId)).thenReturn(tokenData);
+    }
+
+}

--- a/src/test/java/com/mindmate/mindmate_server/auth/TokenServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/TokenServiceTest.java
@@ -1,0 +1,215 @@
+package com.mindmate.mindmate_server.auth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mindmate.mindmate_server.auth.dto.TokenData;
+import com.mindmate.mindmate_server.auth.service.TokenService;
+import com.mindmate.mindmate_server.auth.util.JwtTokenProvider;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private ObjectMapper objectMapper;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Nested
+    @DisplayName("리프레시 토큰 저장 테스트")
+    class SaveRefreshTokenTest {
+        @Test
+        @DisplayName("리프레시 토큰 저장 성공")
+        void saveRefreshToken_Success() throws JsonProcessingException {
+            // given
+            Long userId = 1L;
+            String refreshToken = "refresh-token";
+            String tokenFamily = "token-family";
+            String tokenDataJson = "token-data-json";
+
+            lenient().when(objectMapper.writeValueAsString(any(TokenData.class))).thenReturn(tokenDataJson);
+
+            // when
+            tokenService.saveRefreshToken(userId, refreshToken, tokenFamily);
+
+            // then
+            verify(valueOperations).set(
+                    eq("RT:" + userId),
+                    eq(tokenDataJson),
+                    eq(7L),
+                    eq(TimeUnit.DAYS)
+            );
+        }
+
+        @Test
+        @DisplayName("JSON 처리 실패시 예외 발생")
+        void saveRefreshToken_JsonProcessingException() throws JsonProcessingException {
+            // given
+            lenient().when(objectMapper.writeValueAsString(any(TokenData.class)))
+                    .thenThrow(new JsonProcessingException("Error"){});
+
+            // when & then
+            assertThrows(CustomException.class, () -> tokenService.saveRefreshToken(1L, "token", "family"));
+        }
+    }
+    @Nested
+    @DisplayName("리프레시 토큰 조회 테스트")
+    class GetRefreshTokenTest {
+        @Test
+        @DisplayName("리프레시 토큰 조회 성공")
+        void getRefreshToken_Success() throws JsonProcessingException {
+            // given
+            Long userId = 1L;
+            String tokenDataJson = "token-data-json";
+            TokenData expectedTokenData = TokenData.of("token", "family");
+
+            when(valueOperations.get("RT:" + userId)).thenReturn(tokenDataJson);
+            when(objectMapper.readValue(eq(tokenDataJson), eq(TokenData.class))).thenReturn(expectedTokenData);
+
+            // when
+            TokenData result = tokenService.getRefreshToken(userId);
+
+            // then
+            assertNotNull(result);
+            assertEquals(expectedTokenData, result);
+        }
+
+        @Test
+        @DisplayName("저장된 토큰이 없을 경우 null 반환")
+        void getRefreshToken_NotFound() {
+            // given
+            when(valueOperations.get(anyString())).thenReturn(null);
+
+            // when
+            TokenData result = tokenService.getRefreshToken(1L);
+
+            // then
+            assertNull(result);
+        }
+
+        @Test
+        @DisplayName("저장된 토큰 조회 시 JSON 처리 실패")
+        void getRefreshToken_JsonProcessingException() throws JsonProcessingException{
+            // given
+            Long userId = 1L;
+            String tokenDataJson = "invalid-json";
+            when(valueOperations.get("RT:" + userId)).thenReturn(tokenDataJson);
+            when(objectMapper.readValue(eq(tokenDataJson), eq(TokenData.class)))
+                    .thenThrow(new JsonProcessingException("Error"){});
+
+            // when & then
+            assertThrows(CustomException.class, () -> tokenService.getRefreshToken(userId));
+        }
+    }
+
+    @Nested
+    @DisplayName("블랙리스트 관련 테스트")
+    class BlacklistTest {
+        @Test
+        @DisplayName("토큰 블랙리스트 추가 성공")
+        void addToBlacklist_Success() {
+            // given
+            String token = "test-token";
+            long expiration = 3600000L;
+
+            when(jwtTokenProvider.getExpirationFromToken(token)).thenReturn(expiration);
+
+            // when
+            tokenService.addToBlackList(token);
+
+            // then
+            verify(valueOperations).set(
+                    eq("BL:" + token),
+                    eq("blacklisted"),
+                    eq(expiration),
+                    eq(TimeUnit.MILLISECONDS)
+            );
+        }
+
+        @Test
+        @DisplayName("토큰 블랙리스트 확인")
+        void isTokenBlacklisted_Success() {
+            // given
+            String token = "test-token";
+            when(redisTemplate.hasKey("BL:" + token)).thenReturn(true);
+
+            // when
+            boolean result = tokenService.isTokenBlacklisted(token);
+
+            // then
+            assertTrue(result);
+            verify(redisTemplate).hasKey("BL:" + token);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 무효화 테스트")
+    class InvalidateTokenTest {
+        @Test
+        @DisplayName("리프레시 토큰 무효화 성공")
+        void invalidateRefreshToken_Success() {
+            // given
+            Long userId = 1L;
+
+            // when
+            tokenService.invalidateRefreshToken(userId);
+
+            // then
+            verify(redisTemplate).delete("RT:" + userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 마스킹 테스트")
+    class MaskTokenTest {
+        @Test
+        @DisplayName("긴 토큰 마스킹 처리")
+        void maskToken_LongToken() {
+            // given
+            String token = "abcdefghijklmnopqrstuvwxyz";
+            String expectedMask = "abcde****************vwxyz";
+
+            // when
+            String result = ReflectionTestUtils.invokeMethod(tokenService, "maskToken", token);
+
+            // then
+            assertEquals(expectedMask, result);
+        }
+
+        @Test
+        @DisplayName("짧은 토큰 마스킹 처리")
+        void maskToken_ShortToken() {
+            // given
+            String token = "abcde";
+            String expectedMask = "*****";
+
+            // when
+            String result = ReflectionTestUtils.invokeMethod(tokenService, "maskToken", token);
+
+            // then
+            assertEquals(expectedMask, result);
+        }
+
+    }
+
+}

--- a/src/test/java/com/mindmate/mindmate_server/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/service/AuthServiceTest.java
@@ -1,10 +1,6 @@
 package com.mindmate.mindmate_server.auth.service;
 
 import com.mindmate.mindmate_server.auth.dto.*;
-import com.mindmate.mindmate_server.auth.service.AuthServiceImpl;
-import com.mindmate.mindmate_server.auth.service.EmailService;
-import com.mindmate.mindmate_server.auth.service.LoginAttemptService;
-import com.mindmate.mindmate_server.auth.service.TokenService;
 import com.mindmate.mindmate_server.auth.util.JwtTokenProvider;
 import com.mindmate.mindmate_server.auth.util.PasswordValidator;
 import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
@@ -123,7 +119,7 @@ class AuthServiceTest {
 
             // then
             verify(user).getVerificationToken();
-            verify(userService).save(user);
+//            verify(userService).save(user);
             verify(emailService).sendVerificationEmail(eq(user), eq(verificationToken));
         }
 
@@ -179,7 +175,7 @@ class AuthServiceTest {
             verify(userService).findVerificationToken(token);
             verify(user).verifyEmail();
             verify(user).updateRole(RoleType.ROLE_USER);
-            verify(userService).save(user);
+//            verify(userService).save(user); 영속성
         }
 
         @Test

--- a/src/test/java/com/mindmate/mindmate_server/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/service/AuthServiceTest.java
@@ -1,4 +1,4 @@
-package com.mindmate.mindmate_server.auth;
+package com.mindmate.mindmate_server.auth.service;
 
 import com.mindmate.mindmate_server.auth.dto.*;
 import com.mindmate.mindmate_server.auth.service.AuthServiceImpl;

--- a/src/test/java/com/mindmate/mindmate_server/auth/service/EmailServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/service/EmailServiceTest.java
@@ -1,0 +1,73 @@
+package com.mindmate.mindmate_server.auth.service;
+
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.user.domain.User;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+    @Mock private JavaMailSender mailSender;
+    @Mock private MimeMessage mimeMessage;
+    @Mock private MimeMessageHelper mimeMessageHelper;
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Nested
+    @DisplayName("이메일 전송")
+    class EmailSendTest {
+        @Test
+        @DisplayName("이메일 전송 성공")
+        void sendVerificationEmail_Success() throws MessagingException {
+            // given
+            User user = User.builder()
+                    .email("test@example.com")
+                    .build();
+            String token = "test-token";
+
+            when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+            doNothing().when(mailSender).send(any(MimeMessage.class));
+
+            // when
+            emailService.sendVerificationEmail(user, token);
+
+            // then
+            verify(mailSender).createMimeMessage();
+            verify(mailSender).send(any(MimeMessage.class));
+        }
+
+        @Test
+        @DisplayName("이메일 전송 실패")
+        void sendVerificationEmail_Failed() throws MessagingException {
+            // given
+            User user = User.builder()
+                    .email("test@example.com")
+                    .build();
+            String token = "test-token";
+
+            when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+            doAnswer(invocation -> {
+                throw new MessagingException("Failed to send email");
+            }).when(mailSender).send(any(MimeMessage.class));
+
+            // when & then
+            assertThrows(CustomException.class, () -> emailService.sendVerificationEmail(user, token));
+            verify(mailSender).createMimeMessage();
+            verify(mailSender).send(any(MimeMessage.class));
+        }
+    }
+}

--- a/src/test/java/com/mindmate/mindmate_server/auth/service/LoginAttemptServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/service/LoginAttemptServiceTest.java
@@ -1,0 +1,136 @@
+package com.mindmate.mindmate_server.auth.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoginAttemptServiceTest {
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private LoginAttemptService loginAttemptService;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Nested
+    @DisplayName("로그인 실패 처리 테스트")
+    class LoginFailedTest {
+        @Test
+        @DisplayName("첫 로그인 실패")
+        void loginFailed_FirstAttempt() {
+            // given
+            String email = "test@example.com";
+            when(valueOperations.get("login-attempts:" + email)).thenReturn(null);
+
+            // when
+            loginAttemptService.loginFailed(email);
+
+            // then
+            verify(valueOperations).set(
+                    eq("login-attempts:" + email),
+                    eq("1"),
+                    eq(30L),
+                    eq(TimeUnit.MINUTES)
+            );
+        }
+
+//        @Test
+//        @DisplayName("반복되는 로그인 실패")
+
+        @Test
+        @DisplayName("최대 시도 횟수 초과")
+        void loginFailed_ExceedMaxAttempts() {
+            // given
+            String email = "test@example.com";
+            when(valueOperations.get("login-attempts:" + email)).thenReturn("4");
+
+            // when
+            loginAttemptService.loginFailed(email);
+
+            // then
+            verify(valueOperations).set(
+                    eq("login-locked:" + email),
+                    eq("LOCKED"),
+                    eq(30L),
+                    eq(TimeUnit.MINUTES)
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 시도 횟수 초기화")
+    void loginSucceeded() {
+        // given
+        String email = "test@example.com";
+
+        // when
+        loginAttemptService.loginSucceeded(email);
+
+        // then
+        verify(redisTemplate).delete("login-attempts:" + email);
+        verify(redisTemplate).delete("login-locked:" + email);
+    }
+
+    @Test
+    @DisplayName("계정 잠금 상태 확인")
+    void isBlocked() {
+        // given
+        String email = "test@exmaple.com";
+        when(redisTemplate.hasKey("login-locked:" + email)).thenReturn(true);
+
+        // when
+        boolean result = loginAttemptService.isBlocked(email);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("현재 로그인 시도 횟수")
+    void getCurrentAttempts() {
+        // given
+        String email = "test@example.com";
+        when(valueOperations.get("login-attempts:" + email)).thenReturn("3");
+
+        // when
+        int attempts = loginAttemptService.getCurrentAttempts(email);
+
+        // then
+        assertEquals(3, attempts);
+    }
+
+    @Test
+    @DisplayName("계정 잠금 남은 시간 확인")
+    void getRemainingLockTime() {
+        // given
+        String email = "test@example.com";
+        when(redisTemplate.getExpire("login-locked:" + email, TimeUnit.MINUTES)).thenReturn(15L);
+
+        // when
+        Long remainingTime = loginAttemptService.getRemainingLockTime(email);
+
+        // then
+        assertEquals(15L, remainingTime);
+    }
+
+
+
+}

--- a/src/test/java/com/mindmate/mindmate_server/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/service/TokenServiceTest.java
@@ -1,4 +1,4 @@
-package com.mindmate.mindmate_server.auth;
+package com.mindmate.mindmate_server.auth.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/com/mindmate/mindmate_server/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/profile/service/ProfileServiceTest.java
@@ -1,0 +1,165 @@
+package com.mindmate.mindmate_server.profile.service;
+
+import com.mindmate.mindmate_server.auth.util.SecurityUtil;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.user.domain.*;
+import com.mindmate.mindmate_server.user.dto.ListenerProfileRequest;
+import com.mindmate.mindmate_server.user.dto.ProfileResponse;
+import com.mindmate.mindmate_server.user.dto.ProfileStatusResponse;
+import com.mindmate.mindmate_server.user.dto.SpeakerProfileRequest;
+import com.mindmate.mindmate_server.user.repository.ListenerRepository;
+import com.mindmate.mindmate_server.user.repository.SpeakerRepository;
+import com.mindmate.mindmate_server.user.service.ProfileServiceImpl;
+import com.mindmate.mindmate_server.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+    @Mock private UserService userService;
+    @Mock private ListenerRepository listenerRepository;
+    @Mock private SpeakerRepository speakerRepository;
+    @Mock private SecurityUtil securityUtil;
+
+    @InjectMocks
+    private ProfileServiceImpl profileService;
+
+    private User mockUser;
+
+    @BeforeEach
+    void setup() {
+        mockUser = createDefaultUser();
+        when(securityUtil.getCurrentUser()).thenReturn(mockUser);
+        when(userService.findUserById(any())).thenReturn(mockUser);
+    }
+
+    @Nested
+    @DisplayName("리스너 프로필 생성 테스트")
+    class CreateListenerProfileTest {
+        @Test
+        @DisplayName("리스너 프로필 생성 성공")
+        void createListenerProfile_Success() {
+            // given
+            ListenerProfileRequest request = createListenerRequest();
+
+            when(userService.findUserById(any())).thenReturn(mockUser);
+            when(speakerRepository.existsByNickname(anyString())).thenReturn(false);
+            when(listenerRepository.existsByNickname(anyString())).thenReturn(false);
+
+            // when
+            ProfileResponse response = profileService.createListenerProfile(request);
+
+            // then
+            assertNotNull(response);
+            assertEquals(RoleType.ROLE_LISTENER, response.getRole());
+
+            verify(listenerRepository).save(any(ListenerProfile.class));
+        }
+
+        @Test
+        @DisplayName("중복 닉네임으로 인한 실패")
+        void createListenerProfile_DuplicateNickname() {
+            // given
+            ListenerProfileRequest request = createListenerRequest();
+            when(listenerRepository.existsByNickname(anyString())).thenReturn(true);
+
+            // when & then
+            assertThrows(CustomException.class, () -> profileService.createListenerProfile(request));
+        }
+
+        @Test
+        @DisplayName("이미 프로필이 존재하는 경우 실패")
+        void createListenerProfile_AlreadyExists() {
+            // given
+            ListenerProfile mockProfile = mock(ListenerProfile.class);
+            mockUser.setListenerProfileForTest(mockProfile);
+            ListenerProfileRequest request = createListenerRequest();
+
+            // when & then
+            assertThrows(CustomException.class, () -> profileService.createListenerProfile(request));
+            assertNotNull(mockUser.getListenerProfile());
+        }
+    }
+
+    @Nested
+    @DisplayName("스피커 프로필 생성 테스트")
+    class CreateSpeakerProfileTest {
+        @Test
+        @DisplayName("스피커 프로필 생성 성공")
+        void createSpeakerProfile_Success() {
+            // given
+            SpeakerProfileRequest request = createSpeakerRequest();
+            when(speakerRepository.existsByNickname(any())).thenReturn(false);
+            when(listenerRepository.existsByNickname(any())).thenReturn(false);
+
+            // when
+            ProfileResponse response = profileService.createSpeakerProfile(request);
+
+            // then
+            assertNotNull(response);
+            assertEquals(RoleType.ROLE_SPEAKER, response.getRole());
+            verify(speakerRepository).save(any(SpeakerProfile.class));
+//            verify(mockUser).updateRole(RoleType.ROLE_SPEAKER);
+        }
+    }
+
+    @Nested
+    @DisplayName("역할 전환 테스트")
+    class SwitchRoleTest {
+        @Test
+        @DisplayName("리스너 역할 전환 성공")
+        void switchRole_ToListener_Success() {
+            // given
+            ListenerProfile mockListenerProfile = mock(ListenerProfile.class);
+            mockUser.setListenerProfileForTest(mockListenerProfile);;
+
+            // when
+            ProfileStatusResponse response = profileService.switchRole(RoleType.ROLE_LISTENER);
+
+            // then
+            assertEquals("SUCCESS", response.getStatus());
+            assertEquals(RoleType.ROLE_LISTENER, response.getCurrentRole());
+            assertTrue(response.isHasListenerProfile());
+            assertFalse(response.isHasSpeakerProfile());
+        }
+    }
+
+    private User createDefaultUser() {
+        return User.builder()
+                .email("test@example.com")
+                .password("password")
+                .role(RoleType.ROLE_USER)
+                .build();
+    }
+
+    private ListenerProfileRequest createListenerRequest() {
+        return ListenerProfileRequest.builder()
+                .nickname("listenerNickname")
+                .counselingStyle(CounselingStyle.ACTIVE_LISTENING)
+                .availableTime(LocalDateTime.now())
+                .counselingFields(Set.of(CounselingField.CAREER, CounselingField.ADDICTION))
+                .build();
+    }
+
+    private SpeakerProfileRequest createSpeakerRequest() {
+        return SpeakerProfileRequest.builder()
+                .nickname("speakerNickname")
+                .preferredCounselingStyle(CounselingStyle.EMPHATHETIC)
+                .build();
+    }
+
+}

--- a/src/test/java/com/mindmate/mindmate_server/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/profile/service/ProfileServiceTest.java
@@ -136,6 +136,67 @@ class ProfileServiceTest {
             assertTrue(response.isHasListenerProfile());
             assertFalse(response.isHasSpeakerProfile());
         }
+
+        @Test
+        @DisplayName("스피커 역할 전환 성공")
+        void switchRole_ToSpeaker_Success() {
+            // given
+            SpeakerProfile mockSpeakerProfile = mock(SpeakerProfile.class);
+            mockUser.setSpeakerProfileForTest(mockSpeakerProfile);;
+
+            // when
+            ProfileStatusResponse response = profileService.switchRole(RoleType.ROLE_SPEAKER);
+
+            // then
+            assertEquals("SUCCESS", response.getStatus());
+            assertEquals(RoleType.ROLE_SPEAKER, response.getCurrentRole());
+            assertFalse(response.isHasListenerProfile());
+            assertTrue(response.isHasSpeakerProfile());
+        }
+
+        @Test
+        @DisplayName("리스너 프로필 없이 역할 전환 시도 실패")
+        void switchRole_ToListenerWithoutProfile_Fail() {
+            // when
+            ProfileStatusResponse response = profileService.switchRole(RoleType.ROLE_LISTENER);
+
+            // then
+            assertEquals("PROFILE_REQUIRED", response.getStatus());
+            assertEquals(RoleType.ROLE_USER, response.getCurrentRole());
+            assertFalse(response.isHasListenerProfile());
+        }
+
+        @Test
+        @DisplayName("스피커 프로필 없이 역할 전환 시도 실패")
+        void switchRole_ToSpeakerWithoutProfile_Fail() {
+            // when
+            ProfileStatusResponse response = profileService.switchRole(RoleType.ROLE_SPEAKER);
+
+            // then
+            assertEquals("PROFILE_REQUIRED", response.getStatus());
+            assertEquals(RoleType.ROLE_USER, response.getCurrentRole());
+            assertFalse(response.isHasSpeakerProfile());
+        }
+
+        @Test
+        @DisplayName("동일한 역할로 전환 시도 실패")
+        void switchRole_SameRole_Fail() {
+            // given
+            mockUser.updateRole(RoleType.ROLE_LISTENER);
+            ListenerProfile mockListenerProfile = mock(ListenerProfile.class);
+            mockUser.setListenerProfileForTest(mockListenerProfile);
+
+            // when & then
+            assertThrows(CustomException.class, () -> profileService.switchRole(RoleType.ROLE_LISTENER));
+        }
+
+        @Test
+        @DisplayName("잘못된 역할로 전환 시도 실패")
+        void switchRole_InvalidRole_Fail() {
+            // when & then
+            assertThrows(CustomException.class, () -> profileService.switchRole(RoleType.ROLE_ADMIN));
+        }
+
     }
 
     private User createDefaultUser() {

--- a/src/test/java/com/mindmate/mindmate_server/user/service/UserServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/user/service/UserServiceTest.java
@@ -1,0 +1,171 @@
+package com.mindmate.mindmate_server.user.service;
+
+import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.global.exception.UserErrorCode;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Nested
+    @DisplayName("사용자 조회 테스트")
+    class FindUserTest {
+        @Test
+        @DisplayName("ID로 사용자 조회 성공")
+        void findUserById_Success() {
+            // given
+            Long userId = 1L;
+            User expectedUser = createUser();
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(expectedUser));
+
+            // when
+            User foundUser = userService.findUserById(userId);
+
+            // then
+            assertNotNull(foundUser);
+            assertEquals(expectedUser.getEmail(), foundUser.getEmail());
+            verify(userRepository).findById(userId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID로 조회 시 예외 발생")
+        void findUserById_UserNotFound() {
+            // given
+            Long userId = 999L;
+
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> userService.findUserById(userId));
+            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+            // then
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일 관련 테스트")
+    class EmailVerificationTest {
+        @Test
+        @DisplayName("이메일로 사용자 조회 성공")
+        void findByEmail_Success() {
+            // given
+            String email = "test@example.com";
+            User expectedUser = createUser();
+
+            when(userRepository.findByEmail(email)).thenReturn(Optional.of(expectedUser));
+
+            // when
+            User foundUser = userService.findByEmail(email);
+
+            // then
+            assertNotNull(foundUser);
+            assertEquals(email, foundUser.getEmail());
+            verify(userRepository).findByEmail(email);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이메일로 사용자 조회 실패")
+        void findByEmail_UserNotFound() {
+            // given
+            String email = "nonexist@example.com";
+            when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> userService.findByEmail(email));
+            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("이메일 존재 여부 확인 - 존재하는 경우")
+        void existsByEmail_True() {
+            // given
+            String email = "test@example.com";
+            when(userRepository.existsByEmail(email)).thenReturn(true);
+
+            // when
+            boolean exists = userService.existsByEmail(email);
+
+            // then
+            assertTrue(exists);
+            verify(userRepository).existsByEmail(email);
+        }
+
+        @Test
+        @DisplayName("토큰으로 사용자 조회 성공")
+        void findVerificationToken_Success() {
+            // given
+            String token = "valid-token";
+            User expectedUser = createUser();
+
+            when(userRepository.findByVerificationToken(token)).thenReturn(Optional.of(expectedUser));
+
+            // when
+            User foundUser = userService.findVerificationToken(token);
+
+            // then
+            assertNotNull(foundUser);
+            verify(userRepository).findByVerificationToken(token);
+        }
+
+        @Test
+        @DisplayName("잘못된 토큰으로 조히 시 예외 발생")
+        void findVerificationToken_InvalidToken() {
+            // given
+            String token = "invalid-token";
+
+            when(userRepository.findByVerificationToken(token)).thenReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> userService.findVerificationToken(token));
+            assertEquals(AuthErrorCode.INVALID_TOKEN, exception.getErrorCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 저장 테스트")
+    class SaveUserTest {
+        @Test
+        @DisplayName("사용자 저장 성공")
+        void save_Success() {
+            // given
+            User user = createUser();
+            when(userRepository.save(any(User.class))).thenReturn(user);
+
+            // when
+            userService.save(user);
+
+            // then
+            verify(userRepository).save(user);
+        }
+    }
+
+    private User createUser() {
+        return User.builder()
+                .email("test@example.com")
+                .password("password")
+                .role(RoleType.ROLE_USER)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#7 

## 🪐 작업 내용
- 테스트 코드 작성 (auth, loginAttempt, email, user, profile, token)
- 주석 추가
- 코드 수정 (이메일 재전송 로직 추가, 중복 코드 제거, 유효 검사 추가, roleType 설정 수정)

## jacoco 결과
<img width="740" alt="authservice" src="https://github.com/user-attachments/assets/206ae5c4-798b-483b-8288-f186c52dce33" />
<img width="747" alt="tokenservice" src="https://github.com/user-attachments/assets/449e3de1-6fb7-4d96-91c3-3ad706f25cb9" />
<img width="700" alt="로그인시도" src="https://github.com/user-attachments/assets/35415af7-b7ee-4d1e-95b5-1b4e0d7f0811" />
<img width="722" alt="유저서비스" src="https://github.com/user-attachments/assets/e2096143-55a9-416a-8098-81c3193c761d" />
<img width="706" alt="이메일서비스" src="https://github.com/user-attachments/assets/34cf8c9d-034b-4ec0-be43-746737eb687e" />
<img width="853" alt="프로필 서비스" src="https://github.com/user-attachments/assets/a6fbb751-c28d-44ca-889b-7dcf03d86cca" />
