### PR TITLE
[Feat #13] 채팅 관련 로직

### DIFF
--- a/src/main/java/com/mindmate/mindmate_server/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/dto/SignUpRequest.java
@@ -20,6 +20,8 @@ public class SignUpRequest {
     @NotBlank(message = "확인 비밀번호를 입력해주세요.")
     private String confirmPassword;
 
+    // todo : agreement 추가
+
     @Builder
     public SignUpRequest(String email, String password, String confirmPassword) {
         this.email = email;

--- a/src/main/java/com/mindmate/mindmate_server/auth/util/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/util/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.mindmate.mindmate_server.auth.util;
 
 import com.mindmate.mindmate_server.auth.service.TokenService;
+import com.mindmate.mindmate_server.chat.domain.UserPrincipal;
 import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
 import com.mindmate.mindmate_server.global.exception.CustomException;
 import com.mindmate.mindmate_server.user.domain.User;
@@ -53,8 +54,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         new SimpleGrantedAuthority(user.getCurrentRole().getKey())
                 );
 
+                UserPrincipal userPrincipal = new UserPrincipal(user.getId());
+
                 UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(user, null, authorities);
+                        new UsernamePasswordAuthenticationToken(userPrincipal, null, authorities);
 
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/mindmate/mindmate_server/auth/util/SecurityUtil.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/util/SecurityUtil.java
@@ -1,23 +1,35 @@
 package com.mindmate.mindmate_server.auth.util;
 
+import com.mindmate.mindmate_server.chat.domain.UserPrincipal;
 import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
 import com.mindmate.mindmate_server.global.exception.CustomException;
 import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.repository.UserRepository;
+import com.mindmate.mindmate_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class SecurityUtil {
-    /**
-     * SecurityContext로부터 현재 사용자 식별
-     */
+    private final UserService userService;
+
     public User getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
             throw new CustomException(AuthErrorCode.UNAUTHORIZED);
         }
 
-        return (User) authentication.getPrincipal();
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserPrincipal) {
+            Long userId = ((UserPrincipal) principal).getUserId();
+            return userService.findUserById(userId);
+        } else if (principal instanceof User) {
+            return (User) principal;
+        }
+
+        throw new CustomException(AuthErrorCode.UNAUTHORIZED);
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/controller/ChatController.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/controller/ChatController.java
@@ -1,0 +1,121 @@
+package com.mindmate.mindmate_server.chat.controller;
+
+import com.mindmate.mindmate_server.chat.domain.UserPrincipal;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageRequest;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageResponse;
+import com.mindmate.mindmate_server.chat.dto.ChatRoomDetailResponse;
+import com.mindmate.mindmate_server.chat.dto.ChatRoomResponse;
+import com.mindmate.mindmate_server.chat.service.ChatPresenceService;
+import com.mindmate.mindmate_server.chat.service.ChatRoomService;
+import com.mindmate.mindmate_server.chat.service.ChatService;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+@Slf4j
+public class ChatController {
+    private final ChatService chatService;
+    private final ChatPresenceService chatPresenceService;
+    private final ChatRoomService chatRoomService;
+
+    /**
+     * 사용자의 모든 채팅방 목록 조회
+     */
+    @GetMapping("/rooms")
+    public ResponseEntity<Page<ChatRoomResponse>> getChatRooms(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<ChatRoomResponse> rooms = chatRoomService.getChatRoomsForUser(
+                principal.getUserId(),
+                PageRequest.of(page, size, Sort.by("lastMessageTime").descending())
+        );
+        return ResponseEntity.ok(rooms);
+    }
+
+
+    /**
+     * 특정 역할로 참여 중인 채팅방 목록 조회
+     */
+    @GetMapping("/rooms/role/{roleType}")
+    public ResponseEntity<Page<ChatRoomResponse>> getChatRoomsByRole(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @PathVariable RoleType roleType) {
+        Page<ChatRoomResponse> rooms = chatRoomService.getChatRoomsByUserRole(
+                principal.getUserId(),
+                PageRequest.of(page, size, Sort.by("lastMessageTime").descending()),
+                roleType);
+        return ResponseEntity.ok(rooms);
+    }
+
+    /**
+     * 메시지 조회
+     */
+    @GetMapping("/rooms/{roomId}/messages")
+    public ResponseEntity<ChatRoomDetailResponse> getChatRoomWithMessages(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long roomId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        ChatRoomDetailResponse response = chatRoomService.getChatRoomWithMessages(
+                principal.getUserId(),
+                roomId,
+                PageRequest.of(page, size, Sort.by("createdAt").descending())
+        );
+
+        chatPresenceService.updateUserStatus(principal.getUserId(), true, roomId);
+        chatService.markAsRead(principal.getUserId(), roomId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 메시지 전송 - rest api 버전
+     * websocket 연결이 불안정/불가능한 상황 사용 (동일 로직임)
+     */
+    @PostMapping("/messages")
+    public ResponseEntity<ChatMessageResponse> sendMessage(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody @Valid ChatMessageRequest request) {
+        ChatMessageResponse response = chatService.sendMessage(principal.getUserId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 채팅방 종료
+     * todo : 매칭 종료와 어떤 식으로 분리해서 처리해야 할지 고민
+     */
+    @PostMapping("/rooms/{roomId}/close")
+    public ResponseEntity<Void> closeChatRoom(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long roomId) {
+        chatRoomService.closeChatRoom(principal.getUserId(), roomId);
+
+        // 채팅방 상태 변경 알림
+//        ChatRoomStatusNotification notification = ChatRoomStatusNotification.builder()
+//                .roomId(roomId)
+//                .status("CLOSED")
+//                .updatedBy(principal.getUserId())
+//                .timestamp(LocalDateTime.now())
+//                .build();
+//
+//        messagingTemplate.convertAndSend("/topic/chat.room." + roomId + ".status", notification);
+
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/controller/WebSocketChatController.java
@@ -26,12 +26,15 @@ public class WebSocketChatController {
      * websocket을 통한 메시지 전송
      */
     @MessageMapping("/chat.send")
-    @SendTo("/topic/chat.room.{roomId}")
     public ChatMessageResponse sendMessage(
             @Payload ChatMessageRequest request,
             Principal principal) {
         Long userId = Long.parseLong(principal.getName());
         log.info("Received WebSocket message from user {}: {}", userId, request);
+
+        String destination = "/topic/chat.room." + request.getRoomId();
+        messagingTemplate.convertAndSend(destination, request);
+
         return chatService.sendMessage(userId, request);
     }
 

--- a/src/main/java/com/mindmate/mindmate_server/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/controller/WebSocketChatController.java
@@ -1,0 +1,99 @@
+package com.mindmate.mindmate_server.chat.controller;
+
+import com.mindmate.mindmate_server.chat.dto.*;
+import com.mindmate.mindmate_server.chat.service.ChatPresenceService;
+import com.mindmate.mindmate_server.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketChatController {
+    private final ChatService chatService;
+    private final ChatPresenceService chatPresenceService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * websocket을 통한 메시지 전송
+     */
+    @MessageMapping("/chat.send")
+    @SendTo("/topic/chat.room.{roomId}")
+    public ChatMessageResponse sendMessage(
+            @Payload ChatMessageRequest request,
+            Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        log.info("Received WebSocket message from user {}: {}", userId, request);
+        return chatService.sendMessage(userId, request);
+    }
+
+    /**
+     * 사용자 상태 업데이트
+     */
+    @MessageMapping("/presence")
+    public void updatePresence(
+            @Payload PresenceRequest presenceRequest,
+            Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        log.info("Updating user presence: userId={}, status={}",
+                userId, presenceRequest.getStatus());
+
+        boolean isOnline = "ONLINE".equals(presenceRequest.getStatus());
+        chatPresenceService.updateUserStatus(
+                userId,
+                isOnline,
+                presenceRequest.getActiveRoomId()
+        );
+    }
+
+    /**
+     * 타이핑 상태 알림??
+     * 사용자가 메시지 입력 중인거 알릴건가?
+     */
+//    @MessageMapping("/chat.typing")
+//    public void notifyTyping(
+//            @Payload TypingRequest request,
+//            Principal principal) {
+//        Long userId = Long.parseLong(principal.getName());
+
+        // 타이핑 상태 정보 생성
+//        TypingNotification notification = TypingNotification.builder()
+//                .roomId(request.getRoomId())
+//                .userId(userId)
+//                .typing(request.isTyping())
+//                .build();
+
+        // 해당 채팅방의 상대방에게 타이핑 상태 전송
+//        messagingTemplate.convertAndSend("/topic/chat.room." + request.getRoomId() + ".typing", notification);
+//    }
+
+    /**
+     * 읽음 상태 업데이트 (WebSocket)
+     * - 실시간으로 메시지 읽음 상태 업데이트
+     */
+    @MessageMapping("/chat.read")
+    public void markAsRead(
+            @Payload ReadRequest request,
+            Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        chatService.markAsRead(userId, request.getRoomId());
+
+        // 읽음 상태 알림 생성
+        ReadStatusNotification notification = ReadStatusNotification.builder()
+                .roomId(request.getRoomId())
+                .userId(userId)
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        // 해당 채팅방의 모든 참가자에게 읽음 상태 전송
+        messagingTemplate.convertAndSend("/topic/chat.room." + request.getRoomId() + ".read", notification);
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatMessage.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatMessage.java
@@ -35,6 +35,8 @@ public class ChatMessage extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    private String filteredContent;
+
     @Enumerated(EnumType.STRING)
     private MessageType type;
 
@@ -52,5 +54,9 @@ public class ChatMessage extends BaseTimeEntity {
         this.isRead = false;
 
         // todo : 메시지 생성 시 상대방의 읽은 않은 메시지 수 증가? -> 온라인/오프라인 여부 확인해야함
+    }
+
+    public void setFilteredContent(String filteredContent) {
+        this.filteredContent = filteredContent;
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatMessage.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatMessage.java
@@ -43,10 +43,10 @@ public class ChatMessage extends BaseTimeEntity {
 //    private LocalDateTime expiryTime;
 
     @Builder
-    public ChatMessage(ChatRoom chatRoom, User sender, String content, MessageType type) {
+    public ChatMessage(ChatRoom chatRoom, User sender, RoleType senderRole, String content, MessageType type) {
         this.chatRoom = chatRoom;
         this.sender = sender;
-        this.senderRole = sender.getCurrentRole();
+        this.senderRole = senderRole;
         this.content = content;
         this.type = type;
         this.isRead = false;

--- a/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatMessage.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatMessage.java
@@ -1,0 +1,56 @@
+package com.mindmate.mindmate_server.chat.domain;
+
+import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_messages")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private User sender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RoleType senderRole;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private MessageType type;
+
+    private boolean isRead;
+    private LocalDateTime readAt;
+//    private LocalDateTime expiryTime;
+
+    @Builder
+    public ChatMessage(ChatRoom chatRoom, User sender, String content, MessageType type) {
+        this.chatRoom = chatRoom;
+        this.sender = sender;
+        this.senderRole = sender.getCurrentRole();
+        this.content = content;
+        this.type = type;
+        this.isRead = false;
+
+        // todo : 메시지 생성 시 상대방의 읽은 않은 메시지 수 증가? -> 온라인/오프라인 여부 확인해야함
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatRoom.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatRoom.java
@@ -1,6 +1,7 @@
 package com.mindmate.mindmate_server.chat.domain;
 
 import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
+import com.mindmate.mindmate_server.matching.domain.Matching;
 import com.mindmate.mindmate_server.user.domain.ListenerProfile;
 import com.mindmate.mindmate_server.user.domain.SpeakerProfile;
 import jakarta.persistence.*;
@@ -23,7 +24,10 @@ public class ChatRoom extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // todo : matching 매핑
+    // todo : matching 매핑 + cascade 설정? 매칭이 사라지더라도 해당 데이터는 남길것인가
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "matching_id")
+    private Matching matching;
 
     @Enumerated(EnumType.STRING)
     private ChatRoomStatus chatRoomStatus;
@@ -53,7 +57,8 @@ public class ChatRoom extends BaseTimeEntity {
     private int speakerUnreadCount = 0;
 
     @Builder
-    public ChatRoom(ListenerProfile listener, SpeakerProfile speaker) {
+    public ChatRoom(Matching matching, ListenerProfile listener, SpeakerProfile speaker) {
+        this.matching = matching;
         this.chatRoomStatus = ChatRoomStatus.ACTIVE;
         this.listener = listener;
         this.speaker = speaker;

--- a/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatRoom.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatRoom.java
@@ -1,13 +1,90 @@
 package com.mindmate.mindmate_server.chat.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
+import com.mindmate.mindmate_server.user.domain.ListenerProfile;
+import com.mindmate.mindmate_server.user.domain.SpeakerProfile;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
-public class ChatRoom {
+@Table(name = "chat_rooms")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    // todo : matching 매핑
+
+    @Enumerated(EnumType.STRING)
+    private ChatRoomStatus chatRoomStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "listener_id")
+    private ListenerProfile listener;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "speaker_id")
+    private SpeakerProfile speaker;
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessage> messages = new ArrayList<>();
+
+//    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<ChatRoomParticipant> participants = new ArrayList<>();
+
+    private LocalDateTime lastMessageTime;
+    private LocalDateTime closedAt;
+//    private LocalDateTime expiryTime;
+
+    // 읽음 상태 처리를 chatroomparticipant를 따로 두지 않고 바로 처리?
+    private Long listenerLastReadMessageId = 0L;
+    private Long speakerLastReadMessageId = 0L;
+    private int listenerUnreadCount = 0;
+    private int speakerUnreadCount = 0;
+
+    @Builder
+    public ChatRoom(ListenerProfile listener, SpeakerProfile speaker) {
+        this.chatRoomStatus = ChatRoomStatus.ACTIVE;
+        this.listener = listener;
+        this.speaker = speaker;
+//        this.expiryTime = expiryTime;
+    }
+
+    public void updateLastMessageTime() {
+        this.lastMessageTime = LocalDateTime.now();
+    }
+
+    public void close() {
+        this.chatRoomStatus = ChatRoomStatus.CLOSED;
+        this.closedAt = LocalDateTime.now();
+    }
+
+    public void markAsReadForListener(Long messageId) {
+        this.listenerLastReadMessageId = messageId;
+        this.listenerUnreadCount = 0;
+    }
+
+    public void markAsReadForSpeaker(Long messageId) {
+        this.speakerLastReadMessageId = messageId;
+        this.speakerUnreadCount = 0;
+    }
+
+    public void increaseUnreadCountForListener() {
+        this.listenerUnreadCount++;
+    }
+
+    public void increaseUnreadCountForSpeaker() {
+        this.speakerUnreadCount++;
+    }
+
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatRoomStatus.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/domain/ChatRoomStatus.java
@@ -1,0 +1,11 @@
+package com.mindmate.mindmate_server.chat.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum ChatRoomStatus {
+    ACTIVE,
+    PENDING,
+    CLOSED,
+    DELETED
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/domain/FilteringWordCategory.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/domain/FilteringWordCategory.java
@@ -1,0 +1,40 @@
+package com.mindmate.mindmate_server.chat.domain;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Getter
+public enum FilteringWordCategory {
+    PROFANITY("욕설", Arrays.asList("욕설1", "욕설2", "욕설3")),
+    DISCRIMINATION("차별", Arrays.asList("차별단어1", "차별단어2")),
+    ADULT("성인", Arrays.asList("성인단어1", "성인단어2")),
+    PERSONAL_INFO("개인정보", Arrays.asList("주민번호", "전화번호"));
+
+    private final String description;
+    private final List<String> words;
+
+    FilteringWordCategory(String description, List<String> words) {
+        this.description = description;
+        this.words = words;
+    }
+
+    public static List<String> getAllBannedWords() {
+        return Arrays.stream(values())
+                .flatMap(category -> category.getWords().stream())
+                .collect(Collectors.toList());
+    }
+
+    public boolean containsWord(String text) {
+        return words.stream().anyMatch(text::contains);
+    }
+
+    public static Optional<FilteringWordCategory> findMatchingCategory(String text) {
+        return Arrays.stream(values())
+                .filter(category -> category.containsWord(text))
+                .findFirst();
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/domain/MessageType.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/domain/MessageType.java
@@ -1,0 +1,11 @@
+package com.mindmate.mindmate_server.chat.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum MessageType {
+    TEXT,
+    IMAGE,
+    STICKER,
+    EMOTICON
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/domain/UserPrincipal.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/domain/UserPrincipal.java
@@ -1,0 +1,20 @@
+package com.mindmate.mindmate_server.chat.domain;
+
+import java.security.Principal;
+
+public class UserPrincipal implements Principal {
+    private final Long userId;
+
+    public UserPrincipal(Long userId) {
+        this.userId = userId;
+    }
+
+    @Override
+    public String getName() {
+        return userId.toString();
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageEvent.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageEvent.java
@@ -1,0 +1,28 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import com.mindmate.mindmate_server.chat.domain.MessageType;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageEvent {
+    private Long messageId;
+    private LocalDateTime timestamp;
+    private Long roomId;
+    private Long senderId;
+    private RoleType senderRole;
+    private String content;
+    private MessageType type;
+
+    public void setId(Long id) {
+        this.messageId = id;
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageRequest.java
@@ -1,0 +1,17 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import com.mindmate.mindmate_server.chat.domain.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageRequest {
+    private Long roomId;
+    private String content;
+    private MessageType type;
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageResponse.java
@@ -34,7 +34,7 @@ public class ChatMessageResponse {
                         ? message.getChatRoom().getListener().getNickname()
                         : message.getChatRoom().getSpeaker().getNickname())
                 .senderRole(message.getSenderRole())
-                .content(message.getContent())
+                .content(message.getFilteredContent() != null ? message.getFilteredContent() : message.getContent())
                 .type(message.getType())
                 .createdAt(message.getCreatedAt())
                 .build();

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,43 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
+import com.mindmate.mindmate_server.chat.domain.MessageType;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageResponse {
+    private Long id;
+    private Long roomId;
+    private Long senderId;
+
+    private String senderName;
+    private RoleType senderRole;
+    private String content;
+    private MessageType type;
+    private LocalDateTime createdAt;
+
+    public static ChatMessageResponse from(ChatMessage message) {
+        return ChatMessageResponse.builder()
+                .id(message.getId())
+                .roomId(message.getChatRoom().getId())
+                .senderId(message.getSender().getId())
+                .senderName(message.getSenderRole() == RoleType.ROLE_LISTENER
+                        ? message.getChatRoom().getListener().getNickname()
+                        : message.getChatRoom().getSpeaker().getNickname())
+                .senderRole(message.getSenderRole())
+                .content(message.getContent())
+                .type(message.getType())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatRoomDetailResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatRoomDetailResponse.java
@@ -1,0 +1,26 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class ChatRoomDetailResponse {
+    private Long roomId;
+//    private String matchingName;
+    private List<ChatMessageResponse> messages;
+
+    public static ChatRoomDetailResponse from(ChatRoom chatRoom, List<ChatMessage> messages) {
+        return ChatRoomDetailResponse.builder()
+                .roomId(chatRoom.getId())
+                .messages(messages.stream()
+                        .map(ChatMessageResponse::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ChatRoomResponse.java
@@ -1,0 +1,43 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.domain.ChatRoomStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.checkerframework.common.value.qual.ArrayLen;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatRoomResponse {
+    private Long roomId;
+    private ChatRoomStatus chatRoomStatus;
+    private int unreadCount;
+    private LocalDateTime lastMessageTime;
+    private Long lastReadMessageId;
+
+    private String myName;
+    private String oppositeName;
+
+    public static ChatRoomResponse from(ChatRoom chatRoom, Long userId) {
+        boolean isListener = chatRoom.getListener().getUser().getId().equals(userId);
+        int unreadCount = isListener ? chatRoom.getListenerUnreadCount() : chatRoom.getSpeakerUnreadCount();
+        Long lastReadMessageId = isListener ? chatRoom.getListenerLastReadMessageId() : chatRoom.getSpeakerLastReadMessageId();
+        String myName = isListener ? chatRoom.getListener().getNickname() : chatRoom.getSpeaker().getNickname();
+        String oppositeName = isListener ? chatRoom.getSpeaker().getNickname() : chatRoom.getListener().getNickname();
+
+        return ChatRoomResponse.builder()
+                .roomId(chatRoom.getId())
+                .chatRoomStatus(chatRoom.getChatRoomStatus())
+                .unreadCount(unreadCount)
+                .lastMessageTime(chatRoom.getLastMessageTime())
+                .lastReadMessageId(lastReadMessageId)
+                .myName(myName)
+                .oppositeName(oppositeName)
+                .build();
+    }
+
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/PresenceRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/PresenceRequest.java
@@ -1,0 +1,11 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PresenceRequest {
+    private String status;
+    private Long activeRoomId;
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ReadRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ReadRequest.java
@@ -1,0 +1,10 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReadRequest {
+    private Long roomId;
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ReadRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ReadRequest.java
@@ -1,10 +1,14 @@
 package com.mindmate.mindmate_server.chat.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ReadRequest {
     private Long roomId;
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/ReadStatusNotification.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/ReadStatusNotification.java
@@ -1,0 +1,14 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReadStatusNotification {
+    private Long roomId;
+    private Long userId;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/TypingNotification.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/TypingNotification.java
@@ -1,0 +1,12 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TypingNotification {
+    private Long roomId;
+    private Long userId;
+    private boolean typing;
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/dto/TypingRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/dto/TypingRequest.java
@@ -1,0 +1,11 @@
+package com.mindmate.mindmate_server.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TypingRequest {
+    private Long roomId;
+    private boolean typing;
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatMessageRepository.java
@@ -1,7 +1,10 @@
 package com.mindmate.mindmate_server.chat.repository;
 
 import com.mindmate.mindmate_server.chat.domain.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -10,10 +13,42 @@ import java.util.Optional;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    // 가장 최근 메시지 조회
     Optional<ChatMessage> findTopByChatRoomIdOrderByIdDesc(Long roomId);
 
-    List<ChatMessage> findByChatRoomIdAndIdGreaterThan(
+    // 채팅방의 메시지를 오래된 순으로 조회 (첫 방문용)
+    Page<ChatMessage> findByChatRoomIdOrderByIdAsc(
             @Param("roomId") Long roomId,
-            @Param("lastReadId") Long lastReadId
+            Pageable pageable
     );
+
+    // 채팅방의 메시지를 최신순으로 조회 (재방문용)
+    Page<ChatMessage> findByChatRoomIdOrderByIdDesc(
+            @Param("roomId") Long roomId,
+            Pageable pageable
+    );
+
+    // 특정 메시지 ID 이전의 메시지 조회 (스크롤 업용)
+    Page<ChatMessage> findByChatRoomIdAndIdLessThanOrderByIdDesc(
+            @Param("roomId") Long roomId,
+            @Param("messageId") Long messageId,
+            Pageable pageable
+    );
+
+    // 특정 메시지 ID 이상의 메시지 조회 (읽지 않은 메시지 포함)
+    List<ChatMessage> findByChatRoomIdAndIdGreaterThanEqualOrderByIdAsc(
+            @Param("roomId") Long roomId,
+            @Param("messageId") Long messageId
+    );
+
+    // 특정 메시지 ID 이전의 N개 메시지 조회
+    @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom.id = :roomId AND m.id <= :messageId ORDER BY m.id DESC")
+    List<ChatMessage> findMessagesBeforeIdLimited(
+            @Param("roomId") Long roomId,
+            @Param("messageId") Long messageId,
+            Pageable pageable
+    );
+
+    // 채팅방의 총 메시지 수 조회
+    long countByChatRoomId(Long roomId);
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,9 @@
+package com.mindmate.mindmate_server.chat.repository;
+
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatMessageRepository.java
@@ -2,8 +2,18 @@ package com.mindmate.mindmate_server.chat.repository;
 
 import com.mindmate.mindmate_server.chat.domain.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    Optional<ChatMessage> findTopByChatRoomIdOrderByIdDesc(Long roomId);
+
+    List<ChatMessage> findByChatRoomIdAndIdGreaterThan(
+            @Param("roomId") Long roomId,
+            @Param("lastReadId") Long lastReadId
+    );
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatRoomRepository.java
@@ -1,9 +1,26 @@
 package com.mindmate.mindmate_server.chat.repository;
 
 import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    @Query("SELECT cr FROM ChatRoom cr WHERE cr.listener.user.id = :user OR cr.speaker.user.id = :user")
+    Page<ChatRoom> findAllByParticipant(@Param("user") Long userID, Pageable pageable);
+
+    @Query("SELECT cr FROM ChatRoom cr WHERE (cr.listener.user.id = :user AND cr.listener.user.currentRole = :roleType) " +
+            "OR (cr.speaker.user.id = :user AND cr.speaker.user.currentRole = :roleType)")
+    Page<ChatRoom> findAllByParticipantAndRole(@Param("user") Long userId,
+                                               @Param("roleType") RoleType roleType,
+                                               Pageable pageable);
+    Optional<ChatRoom> findByMatchingId(Long matchingId);
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatRoomRepository.java
@@ -17,10 +17,13 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("SELECT cr FROM ChatRoom cr WHERE cr.listener.user.id = :user OR cr.speaker.user.id = :user")
     Page<ChatRoom> findAllByParticipant(@Param("user") Long userID, Pageable pageable);
 
-    @Query("SELECT cr FROM ChatRoom cr WHERE (cr.listener.user.id = :user AND cr.listener.user.currentRole = :roleType) " +
-            "OR (cr.speaker.user.id = :user AND cr.speaker.user.currentRole = :roleType)")
+    @Query("SELECT cr FROM ChatRoom cr WHERE " +
+            "(cr.listener.user.id = :user AND :roleTypeKey = 'ROLE_LISTENER') OR " +
+            "(cr.speaker.user.id = :user AND :roleTypeKey = 'ROLE_SPEAKER')")
     Page<ChatRoom> findAllByParticipantAndRole(@Param("user") Long userId,
-                                               @Param("roleType") RoleType roleType,
+                                               @Param("roleTypeKey") String roleTypeKey,
                                                Pageable pageable);
+
+
     Optional<ChatRoom> findByMatchingId(Long matchingId);
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,9 @@
+package com.mindmate.mindmate_server.chat.repository;
+
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatMessageService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatMessageService.java
@@ -1,0 +1,7 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
+
+public interface ChatMessageService {
+    ChatMessage findChatMessageById(Long messageId);
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatMessageServiceImpl.java
@@ -1,0 +1,20 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
+import com.mindmate.mindmate_server.chat.repository.ChatMessageRepository;
+import com.mindmate.mindmate_server.global.exception.ChatErrorCode;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageServiceImpl implements ChatMessageService {
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Override
+    public ChatMessage findChatMessageById(Long messageId) {
+        return chatMessageRepository.findById(messageId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.MESSAGE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatPresenceService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatPresenceService.java
@@ -1,5 +1,6 @@
 package com.mindmate.mindmate_server.chat.service;
 
+import com.mindmate.mindmate_server.global.util.RedisKeyManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -17,9 +18,10 @@ import java.util.concurrent.TimeUnit;
 public class ChatPresenceService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final SimpMessagingTemplate messagingTemplate;
+    private final RedisKeyManager redisKeyManager;
 
     public void updateUserStatus(Long userId, boolean isOnline, Long activeRoomId) {
-        String statusKey = "user:status:" + userId;
+        String statusKey = redisKeyManager.getUserStatusKey(userId);
         Map<String, Object> status = new HashMap<>();
         status.put("online", isOnline);
         status.put("activeRoomId", activeRoomId);
@@ -33,27 +35,56 @@ public class ChatPresenceService {
             redisTemplate.expire(statusKey, 1, TimeUnit.HOURS);
         }
 
-        String channel = "user:status:" + userId;
+        String channel = redisKeyManager.getUserStatusChannel(userId);
         redisTemplate.convertAndSend(channel, status);
 
         log.info("User status updated: userId={}, online={}, activeRoom={}", userId, isOnline, activeRoomId);
     }
 
     public String getUserStatus(Long userId) {
-        String statusKey = "user:status:" + userId;
+        String statusKey = redisKeyManager.getUserStatusKey(userId);
         Boolean isOnline = (Boolean) redisTemplate.opsForHash().get(statusKey, "online");
         return Boolean.TRUE.equals(isOnline) ? "ONLINE" : "OFFLINE";
     }
 
     public Long getActiveRoom(Long userId) {
-        String statusKey = "user:status:" + userId;
+        String statusKey = redisKeyManager.getUserStatusKey(userId);
         return (Long) redisTemplate.opsForHash().get(statusKey, "activeRoomId");
     }
 
     public void incrementUnreadCount(Long roomId, Long userId) {
-        String unreadKey = "chat:room:" + roomId + ":unread:" + userId;
+        String unreadKey = redisKeyManager.getUnreadCountKey(roomId, userId);
         Long count = redisTemplate.opsForValue().increment(unreadKey);
 
+        notifyUnreadCount(roomId, userId, count);
+    }
+
+    public void resetUnreadCount(Long roomId, Long userId) {
+        String unreadKey = redisKeyManager.getUnreadCountKey(roomId, userId);
+        redisTemplate.delete(unreadKey);
+
+        notifyUnreadCount(roomId, userId, 0L);
+    }
+
+    public void sendNotification(Long userId, Object notification) {
+        messagingTemplate.convertAndSendToUser(
+                userId.toString(),
+                "/queue/notification",
+                notification
+        );
+    }
+
+    public boolean shouldIncrementUnreadCount(Long userId, Long roomId) {
+        String statusKey = redisKeyManager.getUserStatusKey(userId);
+        Boolean isOnline = (Boolean) redisTemplate.opsForHash().get(statusKey, "online");
+        Long activeRoomId = (Long) redisTemplate.opsForHash().get(statusKey, "activeRoomId");
+
+        // 오프라인이거나 다른 채팅방을 보고 있는 경우 true 반환
+        return isOnline == null || !isOnline || activeRoomId == null || !activeRoomId.equals(roomId);
+    }
+
+
+    private void notifyUnreadCount(Long roomId, Long userId, Long count) {
         Map<String, Object> unreadData = new HashMap<>();
         unreadData.put("roomId", roomId);
         unreadData.put("unreadCount", count);
@@ -62,29 +93,6 @@ public class ChatPresenceService {
                 userId.toString(),
                 "/queue/unread",
                 unreadData
-        );
-    }
-
-    public void resetUnreadCount(Long roomId, Long userId) {
-        String unreadKey = "chat:room:" + roomId + ":unread:" + userId;
-        redisTemplate.delete(unreadKey);
-
-        Map<String, Object> unreadData = new HashMap<>();
-        unreadData.put("roomId", roomId);
-        unreadData.put("unreadCount", 0);
-
-        messagingTemplate.convertAndSendToUser(
-                userId.toString(),
-                "/queue/unread",
-                unreadData
-        );
-    }
-
-    public void sendNotification(Long userId, Object notification) {
-        messagingTemplate.convertAndSendToUser(
-                userId.toString(),
-                "/queue/notification",
-                notification
         );
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatPresenceService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatPresenceService.java
@@ -1,0 +1,90 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatPresenceService {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void updateUserStatus(Long userId, boolean isOnline, Long activeRoomId) {
+        String statusKey = "user:status:" + userId;
+        Map<String, Object> status = new HashMap<>();
+        status.put("online", isOnline);
+        status.put("activeRoomId", activeRoomId);
+        status.put("lastActive", LocalDateTime.now().toString());
+
+        redisTemplate.opsForHash().putAll(statusKey, status);
+
+        if (isOnline) {
+            redisTemplate.expire(statusKey, 30, TimeUnit.MINUTES);
+        } else {
+            redisTemplate.expire(statusKey, 1, TimeUnit.HOURS);
+        }
+
+        String channel = "user:status:" + userId;
+        redisTemplate.convertAndSend(channel, status);
+
+        log.info("User status updated: userId={}, online={}, activeRoom={}", userId, isOnline, activeRoomId);
+    }
+
+    public String getUserStatus(Long userId) {
+        String statusKey = "user:status:" + userId;
+        Boolean isOnline = (Boolean) redisTemplate.opsForHash().get(statusKey, "online");
+        return Boolean.TRUE.equals(isOnline) ? "ONLINE" : "OFFLINE";
+    }
+
+    public Long getActiveRoom(Long userId) {
+        String statusKey = "user:status:" + userId;
+        return (Long) redisTemplate.opsForHash().get(statusKey, "activeRoomId");
+    }
+
+    public void incrementUnreadCount(Long roomId, Long userId) {
+        String unreadKey = "chat:room:" + roomId + ":unread:" + userId;
+        Long count = redisTemplate.opsForValue().increment(unreadKey);
+
+        Map<String, Object> unreadData = new HashMap<>();
+        unreadData.put("roomId", roomId);
+        unreadData.put("unreadCount", count);
+
+        messagingTemplate.convertAndSendToUser(
+                userId.toString(),
+                "/queue/unread",
+                unreadData
+        );
+    }
+
+    public void resetUnreadCount(Long roomId, Long userId) {
+        String unreadKey = "chat:room:" + roomId + ":unread:" + userId;
+        redisTemplate.delete(unreadKey);
+
+        Map<String, Object> unreadData = new HashMap<>();
+        unreadData.put("roomId", roomId);
+        unreadData.put("unreadCount", 0);
+
+        messagingTemplate.convertAndSendToUser(
+                userId.toString(),
+                "/queue/unread",
+                unreadData
+        );
+    }
+
+    public void sendNotification(Long userId, Object notification) {
+        messagingTemplate.convertAndSendToUser(
+                userId.toString(),
+                "/queue/notification",
+                notification
+        );
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomService.java
@@ -1,0 +1,8 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+
+public interface ChatRoomService {
+
+    ChatRoom findChatRoomById(Long roomId);
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.mindmate.mindmate_server.chat.service;
 
 import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageResponse;
 import com.mindmate.mindmate_server.chat.dto.ChatRoomDetailResponse;
 import com.mindmate.mindmate_server.chat.dto.ChatRoomResponse;
 import com.mindmate.mindmate_server.user.domain.RoleType;
@@ -16,7 +17,9 @@ public interface ChatRoomService {
     Page<ChatRoomResponse> getChatRoomsForUser(Long userId, PageRequest pageRequest);
     Page<ChatRoomResponse> getChatRoomsByUserRole(Long userId, PageRequest pageRequest, RoleType roleType);
 
-    ChatRoomDetailResponse getChatRoomWithMessages(Long userId, Long roomId, PageRequest pageRequest);
+    ChatRoomDetailResponse getInitialMessages(Long userId, Long roomId, int size);
+    List<ChatMessageResponse> getPreviousMessages(Long roomId, Long messageId, int size);
+
     void closeChatRoom(Long userId, Long roomId);
 
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomService.java
@@ -1,8 +1,22 @@
 package com.mindmate.mindmate_server.chat.service;
 
 import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.dto.ChatRoomDetailResponse;
+import com.mindmate.mindmate_server.chat.dto.ChatRoomResponse;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
 
 public interface ChatRoomService {
+    // 채팅방 조회
 
     ChatRoom findChatRoomById(Long roomId);
+    Page<ChatRoomResponse> getChatRoomsForUser(Long userId, PageRequest pageRequest);
+    Page<ChatRoomResponse> getChatRoomsByUserRole(Long userId, PageRequest pageRequest, RoleType roleType);
+
+    ChatRoomDetailResponse getChatRoomWithMessages(Long userId, Long roomId, PageRequest pageRequest);
+    void closeChatRoom(Long userId, Long roomId);
+
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomServiceImpl.java
@@ -1,0 +1,20 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.repository.ChatRoomRepository;
+import com.mindmate.mindmate_server.global.exception.ChatErrorCode;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomServiceImpl implements ChatRoomService {
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Override
+    public ChatRoom findChatRoomById(Long roomId) {
+        return chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomServiceImpl.java
@@ -2,6 +2,7 @@ package com.mindmate.mindmate_server.chat.service;
 
 import com.mindmate.mindmate_server.chat.domain.ChatMessage;
 import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageResponse;
 import com.mindmate.mindmate_server.chat.dto.ChatRoomDetailResponse;
 import com.mindmate.mindmate_server.chat.dto.ChatRoomResponse;
 import com.mindmate.mindmate_server.chat.repository.ChatMessageRepository;
@@ -9,7 +10,6 @@ import com.mindmate.mindmate_server.chat.repository.ChatRoomRepository;
 import com.mindmate.mindmate_server.global.exception.ChatErrorCode;
 import com.mindmate.mindmate_server.global.exception.CustomException;
 import com.mindmate.mindmate_server.user.domain.RoleType;
-import com.mindmate.mindmate_server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -17,7 +17,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -26,7 +30,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
 
-    private final UserService userService;
+//    private final UserService userService;
 
     @Override
     public ChatRoom findChatRoomById(Long roomId) {
@@ -42,23 +46,76 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     @Override
     public Page<ChatRoomResponse> getChatRoomsByUserRole(Long userId, PageRequest pageRequest, RoleType roleType) {
-        return chatRoomRepository.findAllByParticipantAndRole(userId, roleType, pageRequest)
+        return chatRoomRepository.findAllByParticipantAndRole(userId, roleType.getKey(), pageRequest)
                 .map(chatRoom -> ChatRoomResponse.from(chatRoom, userId));
     }
 
     @Override
-    public ChatRoomDetailResponse getChatRoomWithMessages(Long userId, Long roomId, PageRequest pageRequest) {
+    public ChatRoomDetailResponse getInitialMessages(Long userId, Long roomId, int size) {
         ChatRoom chatRoom = findChatRoomById(roomId);
         boolean isListener = chatRoom.getListener().getUser().getId().equals(userId);
 
-        Long lastReadMessage = isListener
+        Long lastReadMessageId = isListener
                 ? chatRoom.getListenerLastReadMessageId()
                 : chatRoom.getSpeakerLastReadMessageId();
 
-        List<ChatMessage> messages = chatMessageRepository.findByChatRoomIdAndIdGreaterThan(roomId, lastReadMessage);
+        List<ChatMessage> messages;
+
+        // 채팅방 총 메시지 수 확인
+        long totalMessages = chatMessageRepository.countByChatRoomId(roomId);
+
+        if (lastReadMessageId == 0) {
+            // 1. 처음 채팅방에 들어가는 경우 -> 가장 오래된 메시지부터 보여주기
+            messages = new ArrayList<>(chatMessageRepository.findByChatRoomIdOrderByIdAsc(
+                    roomId, PageRequest.of(0, (int)Math.min(totalMessages, size))).getContent());
+        } else {
+            // 마지막으로 읽은 메시지 이후의 메시지가 있는지 확인
+            Optional<ChatMessage> latestMessageOpt = chatMessageRepository.findTopByChatRoomIdOrderByIdDesc(roomId);
+
+            if (latestMessageOpt.isPresent() && latestMessageOpt.get().getId() > lastReadMessageId) {
+                // 2. 읽지 않은 메시지가 있는 경우
+                // 마지막으로 읽은 메시지 이전의 10개 메시지 가져오기
+                List<ChatMessage> previousMessages = new ArrayList<>(chatMessageRepository.findMessagesBeforeIdLimited(
+                        roomId, lastReadMessageId, PageRequest.of(0, 10)));
+
+                // 마지막으로 읽은 메시지 포함 이후의 모든 새 메시지 가져오기
+                List<ChatMessage> newMessages = chatMessageRepository.findByChatRoomIdAndIdGreaterThanEqualOrderByIdAsc(
+                        roomId, lastReadMessageId);
+
+                // 이전 메시지는 역순이므로 뒤집어서 시간순 정렬
+                Collections.reverse(previousMessages);
+
+                // 두 리스트 합치기
+                messages = new ArrayList<>();
+                messages.addAll(previousMessages);
+                messages.addAll(newMessages);
+            } else {
+                // 3. 안 읽은 메시지가 없을 때 -> 최신 메시지 보여주기
+                List<ChatMessage> tempMessages = chatMessageRepository.findByChatRoomIdOrderByIdDesc(
+                        roomId, PageRequest.of(0, size)).getContent();
+                messages = new ArrayList<>(tempMessages);
+                Collections.reverse(messages); // 시간순 정렬
+            }
+        }
 
         return ChatRoomDetailResponse.from(chatRoom, messages);
     }
+
+    @Override
+    public List<ChatMessageResponse> getPreviousMessages(Long roomId, Long messageId, int size) {
+        // 4. 이전 메시지 페이지네이션 (스크롤 업)
+        List<ChatMessage> tempMessages = chatMessageRepository.findByChatRoomIdAndIdLessThanOrderByIdDesc(
+                roomId, messageId, PageRequest.of(0, size)).getContent();
+
+        // 시간순 정렬 (오래된 메시지부터)
+        List<ChatMessage> messages = new ArrayList<>(tempMessages);
+        Collections.reverse(messages);
+
+        return messages.stream()
+                .map(ChatMessageResponse::from)
+                .collect(Collectors.toList());
+    }
+
 
     @Override
     @Transactional

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatRoomServiceImpl.java
@@ -1,20 +1,74 @@
 package com.mindmate.mindmate_server.chat.service;
 
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
 import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.dto.ChatRoomDetailResponse;
+import com.mindmate.mindmate_server.chat.dto.ChatRoomResponse;
+import com.mindmate.mindmate_server.chat.repository.ChatMessageRepository;
 import com.mindmate.mindmate_server.chat.repository.ChatRoomRepository;
 import com.mindmate.mindmate_server.global.exception.ChatErrorCode;
 import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ChatRoomServiceImpl implements ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    private final UserService userService;
 
     @Override
     public ChatRoom findChatRoomById(Long roomId) {
         return chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    @Override
+    public Page<ChatRoomResponse> getChatRoomsForUser(Long userId, PageRequest pageRequest) {
+        return chatRoomRepository.findAllByParticipant(userId, pageRequest)
+                .map(chatRoom -> ChatRoomResponse.from(chatRoom, userId));
+    }
+
+    @Override
+    public Page<ChatRoomResponse> getChatRoomsByUserRole(Long userId, PageRequest pageRequest, RoleType roleType) {
+        return chatRoomRepository.findAllByParticipantAndRole(userId, roleType, pageRequest)
+                .map(chatRoom -> ChatRoomResponse.from(chatRoom, userId));
+    }
+
+    @Override
+    public ChatRoomDetailResponse getChatRoomWithMessages(Long userId, Long roomId, PageRequest pageRequest) {
+        ChatRoom chatRoom = findChatRoomById(roomId);
+        boolean isListener = chatRoom.getListener().getUser().getId().equals(userId);
+
+        Long lastReadMessage = isListener
+                ? chatRoom.getListenerLastReadMessageId()
+                : chatRoom.getSpeakerLastReadMessageId();
+
+        List<ChatMessage> messages = chatMessageRepository.findByChatRoomIdAndIdGreaterThan(roomId, lastReadMessage);
+
+        return ChatRoomDetailResponse.from(chatRoom, messages);
+    }
+
+    @Override
+    @Transactional
+    public void closeChatRoom(Long userId, Long roomId) {
+        ChatRoom chatRoom = findChatRoomById(roomId);
+        if (!chatRoom.getListener().getUser().getId().equals(userId) &&
+                !chatRoom.getSpeaker().getUser().getId().equals(userId)) {
+            throw new CustomException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+        chatRoom.close();
+        log.info("Closed chat room {}", roomId);
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatService.java
@@ -1,12 +1,13 @@
 package com.mindmate.mindmate_server.chat.service;
 
 import com.mindmate.mindmate_server.chat.dto.ChatMessageRequest;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageResponse;
 
 public interface ChatService {
-    void sendMessage(Long userId, ChatMessageRequest request);
+    ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request);
 
-    void markAsRead(Long userId, Long roomId);
+    int markAsRead(Long userId, Long roomId);
 
-    void updateUserStatus(Long userId, boolean isOnline, Long activeRoomId);
+//    void updateUserStatus(Long userId, boolean isOnline, Long activeRoomId);
 
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatService.java
@@ -1,0 +1,12 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.dto.ChatMessageRequest;
+
+public interface ChatService {
+    void sendMessage(Long userId, ChatMessageRequest request);
+
+    void markAsRead(Long userId, Long roomId);
+
+    void updateUserStatus(Long userId, boolean isOnline, Long activeRoomId);
+
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatServiceImpl.java
@@ -1,0 +1,87 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageRequest;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+    private final KafkaTemplate<String, ChatMessageEvent> kafkaTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private final ChatRoomService chatRoomService;
+    private final UserService userService;
+
+    @Override
+    public void sendMessage(Long userId, ChatMessageRequest request) {
+        ChatRoom chatRoom = chatRoomService.findChatRoomById(request.getRoomId());
+        User user = userService.findUserById(userId);
+
+        ChatMessageEvent event = ChatMessageEvent.builder()
+                .roomId(chatRoom.getId())
+                .senderId(userId)
+                .senderRole(user.getCurrentRole())
+                .content(request.getContent())
+                .type(request.getType())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        kafkaTemplate.send("chat-message-topic", event.getRoomId().toString(), event);
+        log.info("Chat message sent to Kafka: {}", event);
+    }
+
+    @Override
+    public void markAsRead(Long userId, Long roomId) {
+        String key = "chat:room:" + roomId + ":read:" + userId;
+        redisTemplate.opsForValue().set(key, LocalDateTime.now().toString());
+
+        Map<String, Object> readEvent = new HashMap<>();
+        readEvent.put("type", "READ_STATUS");
+        readEvent.put("roomId", roomId);
+        readEvent.put("userId", userId);
+        readEvent.put("timestamp", LocalDateTime.now());
+
+        String channel = "chat:room:" + roomId;
+        try {
+            redisTemplate.convertAndSend(channel, objectMapper.writeValueAsString(readEvent));
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing read event", e);
+        }
+    }
+
+    @Override
+    public void updateUserStatus(Long userId, boolean isOnline, Long activeRoomId) {
+        String statusKey = "user:status:" + userId;
+        Map<String, Object> status = new HashMap<>();
+        status.put("online", isOnline);
+        status.put("activeRoomId", activeRoomId);
+        status.put("lastActive", LocalDateTime.now());
+
+        redisTemplate.opsForHash().putAll(statusKey, status);
+
+        if (isOnline) {
+            redisTemplate.expire(statusKey, 30, TimeUnit.MINUTES);
+        }
+
+        String channel = "user:status:" + userId;
+        redisTemplate.convertAndSend(channel, status);
+
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatServiceImpl.java
@@ -82,9 +82,7 @@ public class ChatServiceImpl implements ChatService {
             log.error("Error serializing message", e);
         }
 
-        // 채팅 메시지의 저장이 비동기로 처리되므로 해당 id를 알 수가 없음 -> roomid를 파티션 키로 사용하여 동일한 채팅방의 메시지는 항상 같은 파티션으로 전달
         kafkaTemplate.send("chat-message-topic", event.getRoomId().toString(), event);
-        log.info("Chat message sent to Kafka: {}", event);
         return chatMessageResponse;
     }
 
@@ -92,6 +90,10 @@ public class ChatServiceImpl implements ChatService {
     public int markAsRead(Long userId, Long roomId) {
         ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
         User user = userService.findUserById(userId);
+
+        log.info("Sender user {}", user);
+        log.info("ChatRoom Listener info {}", chatRoom.getListener().getUser());
+        log.info("ChatRoom Speaker info {}", chatRoom.getSpeaker().getUser());
 
         validateChatRoomAccess(chatRoom, user);
         boolean isListener = isUserListener(chatRoom, user);

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ChatServiceImpl.java
@@ -2,9 +2,14 @@ package com.mindmate.mindmate_server.chat.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
 import com.mindmate.mindmate_server.chat.domain.ChatRoom;
 import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
 import com.mindmate.mindmate_server.chat.dto.ChatMessageRequest;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageResponse;
+import com.mindmate.mindmate_server.chat.repository.ChatMessageRepository;
+import com.mindmate.mindmate_server.global.exception.ChatErrorCode;
+import com.mindmate.mindmate_server.global.exception.CustomException;
 import com.mindmate.mindmate_server.user.domain.User;
 import com.mindmate.mindmate_server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -12,14 +17,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 @Service
 @Slf4j
+@Transactional
 @RequiredArgsConstructor
 public class ChatServiceImpl implements ChatService {
     private final KafkaTemplate<String, ChatMessageEvent> kafkaTemplate;
@@ -28,9 +34,11 @@ public class ChatServiceImpl implements ChatService {
 
     private final ChatRoomService chatRoomService;
     private final UserService userService;
+//    private final ChatMessageService chatMessageService;
+    private final ChatMessageRepository chatMessageRepository;
 
     @Override
-    public void sendMessage(Long userId, ChatMessageRequest request) {
+    public ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request) {
         ChatRoom chatRoom = chatRoomService.findChatRoomById(request.getRoomId());
         User user = userService.findUserById(userId);
 
@@ -43,12 +51,49 @@ public class ChatServiceImpl implements ChatService {
                 .timestamp(LocalDateTime.now())
                 .build();
 
+        // todo : redis 채널에 메시지 발행?
+        String channel = "chat:room:" + chatRoom.getId();
+        ChatMessageResponse chatMessageResponse = ChatMessageResponse.builder()
+                .senderId(userId)
+                .senderRole(user.getCurrentRole())
+                .content(request.getContent())
+                .type(request.getType())
+                .createdAt(LocalDateTime.now())
+                .roomId(chatRoom.getId())
+                .build();
+        try {
+            redisTemplate.convertAndSend(channel, objectMapper.writeValueAsString(event));
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing message", e);
+        }
+
+        // 채팅 메시지의 저장이 비동기로 처리되므로 해당 id를 알 수가 없음 -> roomid를 파티션 키로 사용하여 동일한 채팅방의 메시지는 항상 같은 파티션으로 전달
         kafkaTemplate.send("chat-message-topic", event.getRoomId().toString(), event);
         log.info("Chat message sent to Kafka: {}", event);
+        return chatMessageResponse;
     }
 
     @Override
-    public void markAsRead(Long userId, Long roomId) {
+    public int markAsRead(Long userId, Long roomId) {
+        ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
+        User user = userService.findUserById(userId);
+
+        validateChatRoomAccess(chatRoom, user);
+        boolean isListener = isUserListener(chatRoom, user);
+        Long lastMessageId = chatMessageRepository.findTopByChatRoomIdOrderByIdDesc(roomId)
+                .map(ChatMessage::getId)
+                .orElse(0L);
+
+        if (isListener) {
+            chatRoom.markAsReadForListener(lastMessageId);
+        } else {
+            chatRoom.markAsReadForSpeaker(lastMessageId);
+        }
+
+        String unreadKey = "chat:room:" + roomId + ":unread:" + userId;
+        redisTemplate.delete(unreadKey);
+
+
         String key = "chat:room:" + roomId + ":read:" + userId;
         redisTemplate.opsForValue().set(key, LocalDateTime.now().toString());
 
@@ -64,24 +109,37 @@ public class ChatServiceImpl implements ChatService {
         } catch (JsonProcessingException e) {
             log.error("Error serializing read event", e);
         }
+        return 0;
     }
 
-    @Override
-    public void updateUserStatus(Long userId, boolean isOnline, Long activeRoomId) {
-        String statusKey = "user:status:" + userId;
-        Map<String, Object> status = new HashMap<>();
-        status.put("online", isOnline);
-        status.put("activeRoomId", activeRoomId);
-        status.put("lastActive", LocalDateTime.now());
+    private void validateChatRoomAccess(ChatRoom chatRoom, User user) {
+        boolean hasAccess = chatRoom.getListener().getUser().getId().equals(user.getId()) ||
+                chatRoom.getSpeaker().getUser().getId().equals(user.getId());
 
-        redisTemplate.opsForHash().putAll(statusKey, status);
-
-        if (isOnline) {
-            redisTemplate.expire(statusKey, 30, TimeUnit.MINUTES);
+        if (!hasAccess) {
+            throw new CustomException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
         }
-
-        String channel = "user:status:" + userId;
-        redisTemplate.convertAndSend(channel, status);
-
     }
+
+    private boolean isUserListener(ChatRoom chatRoom, User user) {
+        return chatRoom.getListener().getUser().equals(user);
+    }
+
+//    @Override
+//    public void updateUserStatus(Long userId, boolean isOnline, Long activeRoomId) {
+//        String statusKey = "user:status:" + userId;
+//        Map<String, Object> status = new HashMap<>();
+//        status.put("online", isOnline);
+//        status.put("activeRoomId", activeRoomId);
+//        status.put("lastActive", LocalDateTime.now());
+//
+//        redisTemplate.opsForHash().putAll(statusKey, status);
+//
+//        if (isOnline) {
+//            redisTemplate.expire(statusKey, 30, TimeUnit.MINUTES);
+//        }
+//
+//        String channel = "user:status:" + userId;
+//        redisTemplate.convertAndSend(channel, status);
+//    }
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ContentFilterConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ContentFilterConsumer.java
@@ -1,0 +1,61 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
+import com.mindmate.mindmate_server.chat.domain.FilteringWordCategory;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ContentFilterConsumer {
+    private final ContentFilterService contentFilterService;
+
+    private final ChatMessageService chatMessageService;
+
+    @KafkaListener(
+            topics = "chat-message-topic",
+            groupId = "content-filter-group",
+            containerFactory = "chatMessageListenerContainerFactory"
+    )
+    public void filterContent(ConsumerRecord<String, ChatMessageEvent> record) {
+        ChatMessageEvent event = record.value();
+        log.info("Filtering content for message: {}", event);
+
+        if (event.getMessageId() == null) {
+            log.warn("Message ID not set, waiting for storage consumer to process");
+            return;
+        }
+
+        try {
+            Optional<FilteringWordCategory> filteringCategory = contentFilterService.findFilteringWordCategory(event.getContent());
+
+            if (filteringCategory.isPresent()) {
+                log.warn("Banned word detected in message: {}, category: {}",
+                        event.getMessageId(), filteringCategory.get().getDescription());
+
+                ChatMessage message = chatMessageService.findChatMessageById(event.getMessageId());
+
+                // todo : 필터링 처리 어떻게 할 것인지? + 그리고 필터링 후 저장을 원본으로? 아니면 수정해서/
+                // option 1: 아예 다른 내용으로 대체
+                // option 2: 해당 단어만 마스킹
+                if (message != null) {
+                    String warningMessage = String.format(
+                            "[%s 관련 부적절한 내용이 감지되어 삭제되었습니다]",
+                            filteringCategory.get().getDescription());
+
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error filtering content", e);
+        }
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ContentFilterConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ContentFilterConsumer.java
@@ -37,41 +37,31 @@ public class ContentFilterConsumer {
         ChatMessageEvent event = record.value();
         log.info("Filtering content for message: {}", event);
 
-        // todo : 해당 id 설정 독립적 동작 어떻게?
-//        if (event.getMessageId() == null) {
-//            log.warn("Message ID not set, waiting for storage consumer to process");
-//            return;
-//        }
-
         try {
-            Optional<FilteringWordCategory> filteringCategory = contentFilterService.findFilteringWordCategory(event.getContent());
+            ChatMessage message = chatMessageService.findChatMessageById(event.getMessageId());
+            Optional<FilteringWordCategory> filteringCategory = contentFilterService.findFilteringWordCategory(message.getContent());
 
             if (filteringCategory.isPresent()) {
                 log.warn("Banned word detected in message: {}, category: {}",
                         event.getMessageId(), filteringCategory.get().getDescription());
 
-                ChatMessage message = chatMessageService.findChatMessageById(event.getMessageId());
+                // todo : 왜 여기서만 메시지 id 조회가 안될떄가 있을까??
+                String filteredContent = String.format(
+                        "[%s 관련 부적절한 내용이 감지되었습니다]",
+                        filteringCategory.get().getDescription());
+                message.setFilteredContent(filteredContent);
+                // save
 
-                // todo : 필터링 처리 어떻게 할 것인지? + 그리고 필터링 후 저장을 원본으로? 아니면 수정해서/
-                // option 1: 아예 다른 내용으로 대체
-                // option 2: 해당 단어만 마스킹
-                if (message != null) {
-                    String warningMessage = String.format(
-                            "[%s 관련 부적절한 내용이 감지되어 삭제되었습니다]",
-                            filteringCategory.get().getDescription());
+                String channel = "chat:room:" + message.getChatRoom().getId();
+                try {
+                    Map<String, Object> filterEvent = new HashMap<>();
+                    filterEvent.put("type", "CONTENT_FILTERED");
+                    filterEvent.put("messageId", message.getId());
+                    filterEvent.put("content", filteredContent);
 
-                    String channel = "chat:room:" + message.getChatRoom().getId();
-                    try {
-                        Map<String, Object> filterEvent = new HashMap<>();
-                        filterEvent.put("type", "CONTENT_FILTERED");
-                        filterEvent.put("messageId", message.getId());
-                        filterEvent.put("content", message.getContent());
-
-                        redisTemplate.convertAndSend(channel, objectMapper.writeValueAsString(filterEvent));
-                    } catch (JsonProcessingException e) {
-                        log.error("Error serializing filter event", e);
-                    }
-
+                    redisTemplate.convertAndSend(channel, objectMapper.writeValueAsString(filterEvent));
+                } catch (JsonProcessingException e) {
+                    log.error("Error serializing filter event", e);
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ContentFilterConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ContentFilterConsumer.java
@@ -1,15 +1,20 @@
 package com.mindmate.mindmate_server.chat.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mindmate.mindmate_server.chat.domain.ChatMessage;
 import com.mindmate.mindmate_server.chat.domain.FilteringWordCategory;
 import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -18,8 +23,10 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ContentFilterConsumer {
     private final ContentFilterService contentFilterService;
-
     private final ChatMessageService chatMessageService;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     @KafkaListener(
             topics = "chat-message-topic",
@@ -30,10 +37,11 @@ public class ContentFilterConsumer {
         ChatMessageEvent event = record.value();
         log.info("Filtering content for message: {}", event);
 
-        if (event.getMessageId() == null) {
-            log.warn("Message ID not set, waiting for storage consumer to process");
-            return;
-        }
+        // todo : 해당 id 설정 독립적 동작 어떻게?
+//        if (event.getMessageId() == null) {
+//            log.warn("Message ID not set, waiting for storage consumer to process");
+//            return;
+//        }
 
         try {
             Optional<FilteringWordCategory> filteringCategory = contentFilterService.findFilteringWordCategory(event.getContent());
@@ -51,6 +59,18 @@ public class ContentFilterConsumer {
                     String warningMessage = String.format(
                             "[%s 관련 부적절한 내용이 감지되어 삭제되었습니다]",
                             filteringCategory.get().getDescription());
+
+                    String channel = "chat:room:" + message.getChatRoom().getId();
+                    try {
+                        Map<String, Object> filterEvent = new HashMap<>();
+                        filterEvent.put("type", "CONTENT_FILTERED");
+                        filterEvent.put("messageId", message.getId());
+                        filterEvent.put("content", message.getContent());
+
+                        redisTemplate.convertAndSend(channel, objectMapper.writeValueAsString(filterEvent));
+                    } catch (JsonProcessingException e) {
+                        log.error("Error serializing filter event", e);
+                    }
 
                 }
             }

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/ContentFilterService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/ContentFilterService.java
@@ -1,0 +1,30 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.domain.FilteringWordCategory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class ContentFilterService {
+    public boolean containsFilteringWord(String content) {
+        return FilteringWordCategory.getAllBannedWords().stream()
+                .anyMatch(content::contains);
+    }
+
+    public Optional<FilteringWordCategory> findFilteringWordCategory(String content) {
+        return FilteringWordCategory.findMatchingCategory(content);
+    }
+
+    public String maskFilteringWords(String content) {
+        String maskContent = content;
+        for (String word : FilteringWordCategory.getAllBannedWords()) {
+            if (content.contains(word)) {
+                maskContent = maskContent.replace(word, "*".repeat(word.length()));
+            }
+        }
+        return maskContent;
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/MessageStorageConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/MessageStorageConsumer.java
@@ -13,54 +13,54 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
-@Service
-@Transactional
-@RequiredArgsConstructor
-public class MessageStorageConsumer {
+//@Slf4j
+//@Service
+//@Transactional
+//@RequiredArgsConstructor
+//public class MessageStorageConsumer {
     /**
      * 1. 메시지 저장
      * 2. 메시지 필터링
      * 3. 읽은 안읽음 처리
      * 4. 알림 처리
      */
-    private final ChatMessageRepository chatMessageRepository;
+//    private final ChatMessageRepository chatMessageRepository;
+//
+//    private final UserService userService;
+//    private final ChatRoomService chatRoomService;
 
-    private final UserService userService;
-    private final ChatRoomService chatRoomService;
 
 
-
-    @KafkaListener(
-            topics = "chat-message-topic",
-            groupId = "message-storage-group",
-            containerFactory = "chatMessageListenerContainerFactory"
-    )
-    public void processMessageStorage(ConsumerRecord<String, ChatMessageEvent> record) {
-        ChatMessageEvent event = record.value();
-        log.info("Consumed chat message for storage: {}", event);
-
-        try {
-            ChatRoom chatRoom = chatRoomService.findChatRoomById(event.getRoomId());
-            User sender = userService.findUserById(event.getSenderId());
-
-            ChatMessage chatMessage = ChatMessage.builder()
-                    .chatRoom(chatRoom)
-                    .sender(sender)
-                    .senderRole(event.getSenderRole())
-                    .content(event.getContent())
-                    .type(event.getType())
-                    .build();
-
-            ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
-
-            event.setId(savedMessage.getId());
-
-            chatRoom.updateLastMessageTime();
-//            chatRoomRepository.save(chatRoom);
-            log.info("Message saved successfully: id={}", savedMessage.getId());
-        } catch (Exception e) {
-            log.error("Error saving message", e);
-        }
-    }
-}
+//    @KafkaListener(
+//            topics = "chat-message-topic",
+//            groupId = "message-storage-group",
+//            containerFactory = "chatMessageListenerContainerFactory"
+//    )
+//    public void processMessageStorage(ConsumerRecord<String, ChatMessageEvent> record) {
+//        ChatMessageEvent event = record.value();
+//        log.info("Consumed chat message for storage: {}", event);
+//
+//        try {
+//            ChatRoom chatRoom = chatRoomService.findChatRoomById(event.getRoomId());
+//            User sender = userService.findUserById(event.getSenderId());
+//
+//            ChatMessage chatMessage = ChatMessage.builder()
+//                    .chatRoom(chatRoom)
+//                    .sender(sender)
+//                    .senderRole(event.getSenderRole())
+//                    .content(event.getContent())
+//                    .type(event.getType())
+//                    .build();
+//
+//            ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+//
+//            event.setId(savedMessage.getId());
+//
+//            chatRoom.updateLastMessageTime();
+////            chatRoomRepository.save(chatRoom);
+//            log.info("Message saved successfully: id={}", savedMessage.getId());
+//        } catch (Exception e) {
+//            log.error("Error saving message", e);
+//        }
+//    }
+//}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/MessageStorageConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/MessageStorageConsumer.java
@@ -1,0 +1,66 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
+import com.mindmate.mindmate_server.chat.repository.ChatMessageRepository;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MessageStorageConsumer {
+    /**
+     * 1. 메시지 저장
+     * 2. 메시지 필터링
+     * 3. 읽은 안읽음 처리
+     * 4. 알림 처리
+     */
+    private final ChatMessageRepository chatMessageRepository;
+
+    private final UserService userService;
+    private final ChatRoomService chatRoomService;
+
+
+
+    @KafkaListener(
+            topics = "chat-message-topic",
+            groupId = "message-storage-group",
+            containerFactory = "chatMessageListenerContainerFactory"
+    )
+    public void processMessageStorage(ConsumerRecord<String, ChatMessageEvent> record) {
+        ChatMessageEvent event = record.value();
+        log.info("Consumed chat message for storage: {}", event);
+
+        try {
+            ChatRoom chatRoom = chatRoomService.findChatRoomById(event.getRoomId());
+            User sender = userService.findUserById(event.getSenderId());
+
+            ChatMessage chatMessage = ChatMessage.builder()
+                    .chatRoom(chatRoom)
+                    .sender(sender)
+                    .senderRole(event.getSenderRole())
+                    .content(event.getContent())
+                    .type(event.getType())
+                    .build();
+
+            ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+
+            event.setId(savedMessage.getId());
+
+            chatRoom.updateLastMessageTime();
+//            chatRoomRepository.save(chatRoom);
+            log.info("Message saved successfully: id={}", savedMessage.getId());
+        } catch (Exception e) {
+            log.error("Error saving message", e);
+        }
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/NotificationConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/NotificationConsumer.java
@@ -2,7 +2,6 @@ package com.mindmate.mindmate_server.chat.service;
 
 import com.mindmate.mindmate_server.chat.domain.ChatRoom;
 import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
-import com.mindmate.mindmate_server.global.service.FCMService;
 import com.mindmate.mindmate_server.user.domain.RoleType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,74 +13,75 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.Map;
 
-@Service
-@Slf4j
-@RequiredArgsConstructor
-public class NotificationConsumer {
-    private final ChatRoomService chatRoomService;
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final FCMService fcmService;
-
-    @KafkaListener(
-            topics = "chat-message-topic",
-            groupId = "notification-group",
-            containerFactory = "chatMessageListenerContainerFactory"
-    )
-    public void sendNotification(ConsumerRecord<String, ChatMessageEvent> record) {
-        ChatMessageEvent event = record.value();
-        log.info("Processing notification for message: {}", event);
-
-        try {
-            ChatRoom chatRoom = chatRoomService.findChatRoomById(event.getRoomId());
-            Long recipientId;
-            String recipientNickname;
-
-            // 수신자 데이터
-            if (event.getSenderRole() == RoleType.ROLE_LISTENER) {
-                recipientId = chatRoom.getSpeaker().getUser().getId();
-                recipientNickname = chatRoom.getSpeaker().getNickname();
-            } else {
-                recipientId = chatRoom.getListener().getUser().getId();
-                recipientNickname = chatRoom.getListener().getNickname();
-            }
-
-            // 수신자 상태 확인
-            String statusKey = "user:status:" + recipientId;
-            Boolean isOnline = (Boolean) redisTemplate.opsForHash().get(statusKey, "online");
-
-            if (isOnline == null || !isOnline) {
-                // todo : fcm 토큰 조회 -> 사용자 정보에서 가져오기
-                String fcmToken = getFCMToken(recipientId);
-
-                if (fcmToken != null) {
-                    Map<String, String> data = new HashMap<>();
-                    data.put("roomId", event.getRoomId().toString());
-                    data.put("senderId", event.getSenderId().toString());
-                    data.put("senderRole", event.getSenderRole().toString());
-                    data.put("type", event.getType().toString());
-
-                    String messagePreview = event.getContent().length() > 30
-                            ? event.getContent().substring(0, 27)
-                            : event.getContent();
-
-                    fcmService.sendNotification(
-                            fcmToken,
-                            "새 메시지가 도착했습니다",
-                            messagePreview,
-                            data
-                    );
-                    log.info("Push notification sent to user: {}", recipientId);
-                } else {
-                    log.warn("FCM token not found for user: {}", recipientId);
-                }
-            }
-        } catch (Exception e) {
-            log.error("Error sending notification", e);
-        }
-    }
-
-    private String getFCMToken(Long userId) {
-        String tokenKey = "user:fcm:" + userId;
-        return (String) redisTemplate.opsForValue().get(tokenKey);
-    }
-}
+//@Service
+//@Slf4j
+//@RequiredArgsConstructor
+//public class NotificationConsumer {
+//    private final ChatRoomService chatRoomService;
+//    private final RedisTemplate<String, Object> redisTemplate;
+//    private final FCMService fcmService;
+//
+//    // todo : 현재는 온라인/오프라인 여부에 따라 알림 결정하는데 현재 채팅을 보냐 안보냐에 따라 결정해야 할 듯
+//    @KafkaListener(
+//            topics = "chat-message-topic",
+//            groupId = "notification-group",
+//            containerFactory = "chatMessageListenerContainerFactory"
+//    )
+//    public void sendNotification(ConsumerRecord<String, ChatMessageEvent> record) {
+//        ChatMessageEvent event = record.value();
+//        log.info("Processing notification for message: {}", event);
+//
+//        try {
+//            ChatRoom chatRoom = chatRoomService.findChatRoomById(event.getRoomId());
+//            Long recipientId;
+//            String recipientNickname;
+//
+//            // 수신자 데이터
+//            if (event.getSenderRole() == RoleType.ROLE_LISTENER) {
+//                recipientId = chatRoom.getSpeaker().getUser().getId();
+//                recipientNickname = chatRoom.getSpeaker().getNickname();
+//            } else {
+//                recipientId = chatRoom.getListener().getUser().getId();
+//                recipientNickname = chatRoom.getListener().getNickname();
+//            }
+//
+//            // 수신자 상태 확인
+//            String statusKey = "user:status:" + recipientId;
+//            Boolean isOnline = (Boolean) redisTemplate.opsForHash().get(statusKey, "online");
+//
+//            if (isOnline == null || !isOnline) {
+//                // todo : fcm 토큰 조회 -> 사용자 정보에서 가져오기
+//                String fcmToken = getFCMToken(recipientId);
+//
+//                if (fcmToken != null) {
+//                    Map<String, String> data = new HashMap<>();
+//                    data.put("roomId", event.getRoomId().toString());
+//                    data.put("senderId", event.getSenderId().toString());
+//                    data.put("senderRole", event.getSenderRole().toString());
+//                    data.put("type", event.getType().toString());
+//
+//                    String messagePreview = event.getContent().length() > 30
+//                            ? event.getContent().substring(0, 27)
+//                            : event.getContent();
+//
+//                    fcmService.sendNotification(
+//                            fcmToken,
+//                            "새 메시지가 도착했습니다",
+//                            messagePreview,
+//                            data
+//                    );
+//                    log.info("Push notification sent to user: {}", recipientId);
+//                } else {
+//                    log.warn("FCM token not found for user: {}", recipientId);
+//                }
+//            }
+//        } catch (Exception e) {
+//            log.error("Error sending notification", e);
+//        }
+//    }
+//
+//    private String getFCMToken(Long userId) {
+//        String tokenKey = "user:fcm:" + userId;
+//        return (String) redisTemplate.opsForValue().get(tokenKey);
+//    }
+//}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/NotificationConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/NotificationConsumer.java
@@ -1,0 +1,87 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
+import com.mindmate.mindmate_server.global.service.FCMService;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationConsumer {
+    private final ChatRoomService chatRoomService;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final FCMService fcmService;
+
+    @KafkaListener(
+            topics = "chat-message-topic",
+            groupId = "notification-group",
+            containerFactory = "chatMessageListenerContainerFactory"
+    )
+    public void sendNotification(ConsumerRecord<String, ChatMessageEvent> record) {
+        ChatMessageEvent event = record.value();
+        log.info("Processing notification for message: {}", event);
+
+        try {
+            ChatRoom chatRoom = chatRoomService.findChatRoomById(event.getRoomId());
+            Long recipientId;
+            String recipientNickname;
+
+            // 수신자 데이터
+            if (event.getSenderRole() == RoleType.ROLE_LISTENER) {
+                recipientId = chatRoom.getSpeaker().getUser().getId();
+                recipientNickname = chatRoom.getSpeaker().getNickname();
+            } else {
+                recipientId = chatRoom.getListener().getUser().getId();
+                recipientNickname = chatRoom.getListener().getNickname();
+            }
+
+            // 수신자 상태 확인
+            String statusKey = "user:status:" + recipientId;
+            Boolean isOnline = (Boolean) redisTemplate.opsForHash().get(statusKey, "online");
+
+            if (isOnline == null || !isOnline) {
+                // todo : fcm 토큰 조회 -> 사용자 정보에서 가져오기
+                String fcmToken = getFCMToken(recipientId);
+
+                if (fcmToken != null) {
+                    Map<String, String> data = new HashMap<>();
+                    data.put("roomId", event.getRoomId().toString());
+                    data.put("senderId", event.getSenderId().toString());
+                    data.put("senderRole", event.getSenderRole().toString());
+                    data.put("type", event.getType().toString());
+
+                    String messagePreview = event.getContent().length() > 30
+                            ? event.getContent().substring(0, 27)
+                            : event.getContent();
+
+                    fcmService.sendNotification(
+                            fcmToken,
+                            "새 메시지가 도착했습니다",
+                            messagePreview,
+                            data
+                    );
+                    log.info("Push notification sent to user: {}", recipientId);
+                } else {
+                    log.warn("FCM token not found for user: {}", recipientId);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error sending notification", e);
+        }
+    }
+
+    private String getFCMToken(Long userId) {
+        String tokenKey = "user:fcm:" + userId;
+        return (String) redisTemplate.opsForValue().get(tokenKey);
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/UnreadCountConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/UnreadCountConsumer.java
@@ -1,0 +1,61 @@
+package com.mindmate.mindmate_server.chat.service;
+
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class UnreadCountConsumer {
+    private final ChatRoomService chatRoomService;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @KafkaListener(
+            topics = "chat-message-topic",
+            groupId = "unread-count-group",
+            containerFactory = "chatMessageListenerContainerFactory"
+    )
+    public void updateUnreadCount(ConsumerRecord<String, ChatMessageEvent> record) {
+        ChatMessageEvent event = record.value();
+        log.info("Updating unread count for message: {}", event);
+
+        try {
+            ChatRoom chatRoom = chatRoomService.findChatRoomById(event.getRoomId());
+
+            Long recipientId;
+            if (event.getSenderRole() == RoleType.ROLE_LISTENER) {
+                recipientId = chatRoom.getSpeaker().getUser().getId();
+            } else {
+                recipientId = chatRoom.getListener().getUser().getId();
+            }
+
+            // 상태 확인
+            String statusKey = "user:status:" + recipientId;
+            Boolean isOnline = (Boolean) redisTemplate.opsForHash().get(statusKey, "online");
+            Long activeRoomId = (Long) redisTemplate.opsForHash().get(statusKey, "activeRoomId");
+
+            // 오프라인 + 다른 곳을 보고 있는 경우
+            if (isOnline == null || !isOnline || activeRoomId == null || !activeRoomId.equals(event.getRoomId())) {
+                String unreadKey = "chat:room:" + event.getRoomId() + ":unread" + recipientId;
+                redisTemplate.opsForValue().increment(unreadKey);
+
+                if (event.getSenderRole() == RoleType.ROLE_LISTENER) {
+                    chatRoom.increaseUnreadCountForSpeaker();
+                } else {
+                    chatRoom.increaseUnreadCountForListener();
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error updating unread count", e);
+        }
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/UnreadCountConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/UnreadCountConsumer.java
@@ -45,7 +45,7 @@ public class UnreadCountConsumer {
 
             // 오프라인 + 다른 곳을 보고 있는 경우
             if (isOnline == null || !isOnline || activeRoomId == null || !activeRoomId.equals(event.getRoomId())) {
-                String unreadKey = "chat:room:" + event.getRoomId() + ":unread" + recipientId;
+                String unreadKey = "chat:room:" + event.getRoomId() + ":unread:" + recipientId;
                 redisTemplate.opsForValue().increment(unreadKey);
 
                 if (event.getSenderRole() == RoleType.ROLE_LISTENER) {

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/UnreadCountConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/UnreadCountConsumer.java
@@ -4,6 +4,7 @@ import com.mindmate.mindmate_server.chat.domain.ChatRoom;
 import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
 import com.mindmate.mindmate_server.global.util.RedisKeyManager;
 import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -18,9 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UnreadCountConsumer {
     private final ChatRoomService chatRoomService;
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final RedisKeyManager redisKeyManager;
     private final ChatPresenceService chatPresenceService;
+    private final ChatService chatService;
 
     @KafkaListener(
             topics = "chat-message-topic",
@@ -29,27 +29,37 @@ public class UnreadCountConsumer {
     )
     public void updateUnreadCount(ConsumerRecord<String, ChatMessageEvent> record) {
         ChatMessageEvent event = record.value();
-        log.info("Updating unread count for message: {}", event);
 
         try {
             ChatRoom chatRoom = chatRoomService.findChatRoomById(event.getRoomId());
 
-            Long recipientId = (event.getSenderRole() == RoleType.ROLE_LISTENER)
+            // 1. 발신자의 메시지 읽음 처리
+            boolean isSenderListener = event.getSenderRole() == RoleType.ROLE_LISTENER;
+            if (isSenderListener) {
+                chatRoom.markAsReadForListener(event.getMessageId());
+            } else {
+                chatRoom.markAsReadForSpeaker(event.getMessageId());
+            }
+
+            // 2. 수신자 상태 확인
+            Long recipientId = isSenderListener
                     ? chatRoom.getSpeaker().getUser().getId()
                     : chatRoom.getListener().getUser().getId();
 
+            boolean isRecipientOnline = chatPresenceService.isUserActiveInRoom(recipientId, event.getRoomId());
 
-            // 오프라인 + 다른 곳을 보고 있는 경우
-            if (chatPresenceService.shouldIncrementUnreadCount(recipientId, event.getRoomId())) {
-                chatPresenceService.incrementUnreadCount(
-                        event.getRoomId(),
-                        recipientId,
-                        chatRoom,
-                        event.getSenderRole()
-                );
+            if (isRecipientOnline) {
+                // 수신자가 채팅방에 있는 경우 -> 읽음 처리
+                chatService.markAsRead(recipientId, event.getRoomId());
+                log.info("Marked message as read for recipient {} in room {}", recipientId, event.getRoomId());
+
+            } else {
+                // 수신자가 채팅방에 없는 경우 -> 미읽음 카운트 증가
+                chatPresenceService.incrementUnreadCount(event.getRoomId(), recipientId, chatRoom, event.getSenderRole());
+                log.info("Incremented unread count for recipient {} in room {}", recipientId, event.getRoomId());
             }
         } catch (Exception e) {
-            log.error("Error updating unread count", e);
+            log.error("Error processing message event", e);
         }
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/chat/service/UnreadCountConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/service/UnreadCountConsumer.java
@@ -34,22 +34,19 @@ public class UnreadCountConsumer {
         try {
             ChatRoom chatRoom = chatRoomService.findChatRoomById(event.getRoomId());
 
-            Long recipientId;
-            if (event.getSenderRole() == RoleType.ROLE_LISTENER) {
-                recipientId = chatRoom.getSpeaker().getUser().getId();
-            } else {
-                recipientId = chatRoom.getListener().getUser().getId();
-            }
+            Long recipientId = (event.getSenderRole() == RoleType.ROLE_LISTENER)
+                    ? chatRoom.getSpeaker().getUser().getId()
+                    : chatRoom.getListener().getUser().getId();
+
 
             // 오프라인 + 다른 곳을 보고 있는 경우
             if (chatPresenceService.shouldIncrementUnreadCount(recipientId, event.getRoomId())) {
-                chatPresenceService.incrementUnreadCount(event.getRoomId(), recipientId);
-
-                if (event.getSenderRole() == RoleType.ROLE_LISTENER) {
-                    chatRoom.increaseUnreadCountForSpeaker();
-                } else {
-                    chatRoom.increaseUnreadCountForListener();
-                }
+                chatPresenceService.incrementUnreadCount(
+                        event.getRoomId(),
+                        recipientId,
+                        chatRoom,
+                        event.getSenderRole()
+                );
             }
         } catch (Exception e) {
             log.error("Error updating unread count", e);

--- a/src/main/java/com/mindmate/mindmate_server/chat/util/ChatMessageListener.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/util/ChatMessageListener.java
@@ -16,6 +16,10 @@ public class ChatMessageListener implements MessageListener {
     private final SimpMessagingTemplate messagingTemplate;
     private final ObjectMapper objectMapper;
 
+    /**
+     * Redis 채널에서 메시지 수신
+     * 채널 유형에 따라 적절한 처리
+     */
     @Override
     public void onMessage(Message message, byte[] pattern) {
         try {
@@ -34,6 +38,9 @@ public class ChatMessageListener implements MessageListener {
         }
     }
 
+    /**
+     * 채팅방 메시지: WebSocket을 통해 클라이언트에게 전달
+     */
     private void handleChatRoomMessage(String channel, String payload) throws JsonProcessingException {
         String roomId = channel.split(":")[2];
 
@@ -41,6 +48,9 @@ public class ChatMessageListener implements MessageListener {
         messagingTemplate.convertAndSend("/topic/chat/room/" + roomId, payload);
     }
 
+    /**
+     * 사용자 상태 메시지: 상태 변경 알림 전송
+     */
     private void handleUserStatusMessage(String channel, String payload) throws JsonProcessingException {
         String userId = channel.split(":")[2];
 

--- a/src/main/java/com/mindmate/mindmate_server/chat/util/ChatMessageListener.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/util/ChatMessageListener.java
@@ -1,0 +1,50 @@
+package com.mindmate.mindmate_server.chat.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ChatMessageListener implements MessageListener {
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel());
+            String payload = new String(message.getBody());
+
+            log.debug("Received Redis message on channel: {}", channel);
+
+            if (channel.startsWith("chat:room:")) {
+                handleChatRoomMessage(channel, payload);
+            } else if (channel.startsWith("user:status:")) {
+                handleUserStatusMessage(channel, payload);
+            }
+        } catch (Exception e) {
+            log.error("Error processing Redis message", e);
+        }
+    }
+
+    private void handleChatRoomMessage(String channel, String payload) throws JsonProcessingException {
+        String roomId = channel.split(":")[2];
+
+        // WebSocket으로 메시지 전달
+        messagingTemplate.convertAndSend("/topic/chat/room/" + roomId, payload);
+    }
+
+    private void handleUserStatusMessage(String channel, String payload) throws JsonProcessingException {
+        String userId = channel.split(":")[2];
+
+        // 사용자 상태 변경 알림
+        messagingTemplate.convertAndSend("/topic/user/" + userId + "/status", payload);
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/util/ChatSystemRecoveryService.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/util/ChatSystemRecoveryService.java
@@ -1,0 +1,60 @@
+package com.mindmate.mindmate_server.chat.util;
+
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
+import com.mindmate.mindmate_server.chat.dto.ChatRoomResponse;
+import com.mindmate.mindmate_server.chat.repository.ChatRoomRepository;
+import com.mindmate.mindmate_server.chat.service.ChatRoomService;
+import com.mindmate.mindmate_server.global.util.RedisKeyManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+// todo : implements ApplicationListener<ApplicationReadyEvent>
+public class ChatSystemRecoveryService  {
+    private final ChatRoomService chatRoomService;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisKeyManager redisKeyManager;
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    /**
+     * 애플리케이션 시작 시 Redis에 DB 값 동기화
+     */
+//    @Override
+//    public void onApplicationEvent(ApplicationReadyEvent event) {
+//        recoverUnreadCountsFromDb();
+//    }
+
+    /**
+     * 자동 장애 복구
+     */
+    @Scheduled(fixedRate = 1800000)
+    public void scheduledRecovery() {
+        recoverUnreadCountsFromDb();
+    }
+
+    private void recoverUnreadCountsFromDb() {
+        List<ChatRoom> chatRooms = chatRoomRepository.findAll();
+        for (ChatRoom room : chatRooms) {
+            String listenerUnreadKey = redisKeyManager.getUnreadCountKey(
+                    room.getId(),
+                    // todo : LazyInitializationException 발생
+                    room.getListener().getUser().getId()
+            );
+            redisTemplate.opsForValue().set(listenerUnreadKey, String.valueOf(room.getListenerUnreadCount()));
+
+            String speakerUnreadKey = redisKeyManager.getUnreadCountKey(
+                    room.getId(),
+                    room.getSpeaker().getUser().getId()
+            );
+            redisTemplate.opsForValue().set(speakerUnreadKey, String.valueOf(room.getSpeakerUnreadCount()));
+        }
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/chat/util/WebSocketEventListener.java
+++ b/src/main/java/com/mindmate/mindmate_server/chat/util/WebSocketEventListener.java
@@ -1,0 +1,49 @@
+package com.mindmate.mindmate_server.chat.util;
+
+import com.mindmate.mindmate_server.chat.service.ChatPresenceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.security.Principal;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketEventListener {
+    private final ChatPresenceService chatPresenceService;
+
+    /**
+     * 사용자가 웹소켓에 연결될 때 사용자의 상태 온라인으로 업데이트
+     */
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectEvent event) {
+        StompHeaderAccessor headerAccessor = MessageHeaderAccessor.getAccessor(event.getMessage(), StompHeaderAccessor.class);
+        Principal user = headerAccessor.getUser();
+        if (user != null) {
+            Long userId = Long.parseLong(user.getName());
+            log.info("User connected: {}", userId);
+            chatPresenceService.updateUserStatus(userId, true, null);
+        }
+    }
+
+    /**
+     * 웹소켓 연결을 끊을 때 사용자 상태를 오프라인으로 업데이트
+     */
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = MessageHeaderAccessor.getAccessor(event.getMessage(), StompHeaderAccessor.class);
+        Principal user = headerAccessor.getUser();
+        if (user != null) {
+            Long userId = Long.parseLong(user.getName());
+            log.info("User disconnected: {}", userId);
+            chatPresenceService.updateUserStatus(userId, false, null);
+        }
+    }
+}
+

--- a/src/main/java/com/mindmate/mindmate_server/global/config/KafkaConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/KafkaConfig.java
@@ -1,0 +1,92 @@
+package com.mindmate.mindmate_server.global.config;
+
+import com.mindmate.mindmate_server.chat.dto.ChatMessageEvent;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    /**
+     * Producer 설정
+     */
+    @Bean
+    public ProducerFactory<String, ChatMessageEvent> chatMessageProducerFactory() {
+        Map<String, Object> config = new HashMap<>();
+
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    /**
+     * Consumer 설정
+     */
+    @Bean
+    public ConsumerFactory<String, ChatMessageEvent> chatMessageConsumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "chat-group");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
+        return new DefaultKafkaConsumerFactory<>(config);
+    }
+
+    /**
+     * Kafka Template
+     * Message Producer의 편리한 사용을 위한 템플릿
+     */
+    @Bean
+    public KafkaTemplate<String, ChatMessageEvent> chatMessageKafkaTemplate() {
+        return new KafkaTemplate<>(chatMessageProducerFactory());
+    }
+
+    /**
+     * Listener Container Factory
+     * @KafkaListener 어노테이션이 사용할 컨테이너 팩토리
+     * 메시지 리스너의 동시 처리 설정
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ChatMessageEvent> chatMessageListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ChatMessageEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(chatMessageConsumerFactory());
+        return factory;
+    }
+
+    /**
+     * Kafka 토픽 설정
+     */
+    @Bean
+    public NewTopic chatMessageTopic() {
+        return TopicBuilder.name("chat-message-topic")
+                .partitions(3)
+                .replicas(1)
+                .configs(Map.of(
+                        TopicConfig.RETENTION_MS_CONFIG, "604800000",
+                        TopicConfig.CLEANUP_POLICY_CONFIG, "delete"
+                ))
+                .build();
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/global/config/RedisConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/RedisConfig.java
@@ -69,7 +69,7 @@ public class RedisConfig {
         container.setConnectionFactory(connectionFactory);
 
         container.addMessageListener(chatMessageListener, new PatternTopic("chat:room:*"));
-        container.addMessageListener(chatMessageListener, new PatternTopic("user:Status:*"));
+        container.addMessageListener(chatMessageListener, new PatternTopic("user:status:*"));
         return container;
     }
 

--- a/src/main/java/com/mindmate/mindmate_server/global/config/RedisConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.mindmate.mindmate_server.global.config;
 
+import com.mindmate.mindmate_server.chat.util.ChatMessageListener;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,7 +8,10 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -42,6 +46,31 @@ public class RedisConfig {
         template.setDefaultSerializer(new StringRedisSerializer());
         template.afterPropertiesSet();
         return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> objectRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    /**
+     * Redis 구독 설정
+     * 채팅방별 채널 구독 설정?ㅇ
+     */
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            ChatMessageListener chatMessageListener) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+
+        container.addMessageListener(chatMessageListener, new PatternTopic("chat:room:*"));
+        container.addMessageListener(chatMessageListener, new PatternTopic("user:Status:*"));
+        return container;
     }
 
 

--- a/src/main/java/com/mindmate/mindmate_server/global/config/RedisConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/RedisConfig.java
@@ -68,8 +68,8 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
 
-        container.addMessageListener(chatMessageListener, new PatternTopic("chat:room:*"));
-        container.addMessageListener(chatMessageListener, new PatternTopic("user:status:*"));
+        container.addMessageListener(chatMessageListener, new PatternTopic("chat:room:*")); // 채팅방 관련 이벤트 구독
+        container.addMessageListener(chatMessageListener, new PatternTopic("user:status:*")); // 사용자 상태 관련 이벤트 구독
         return container;
     }
 

--- a/src/main/java/com/mindmate/mindmate_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                                                 "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
                                                 "style-src 'self' 'unsafe-inline'; " +
                                                 "img-src 'self' data: https:; " +
-                                                "font-src 'self' data:;"
+                                                "font-src 'self' data:;" +
+                                                "connect-src 'self' ws: wss:;" // WebSocket 연결 허용
                                 )
                         )
                         .httpStrictTransportSecurity(hsts -> // HTTPS 강제
@@ -62,6 +63,7 @@ public class SecurityConfig {
                         .accessDeniedHandler(customAccessDeniedHandler())) // 권한 부족시
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers(
+                            "/ws/**",
                             "/api/**",
 //                            "/api/auth/register",
 //                            "/api/auth/login",
@@ -87,7 +89,9 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:3000",
                 "http://localhost:8080",
-                "ws://localhost:8080"
+                "http://localhost:49170",
+                "ws://localhost:8080",
+                "wss://localhost:8080"
         ));
         configuration.setAllowedMethods(Arrays.asList(
                 "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"
@@ -99,7 +103,10 @@ public class SecurityConfig {
                 "Accept",
                 "Origin",
                 "Access-Control-Request-Method",
-                "Access-Control-Request-Headers"
+                "Access-Control-Request-Headers",
+                "Sec-WebSocket-Protocol",
+                "Sec-WebSocket-Version",
+                "Sec-WebSocket-Key"
         ));
         configuration.setExposedHeaders(Arrays.asList("Authorization"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/mindmate/mindmate_server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/WebSocketConfig.java
@@ -1,0 +1,92 @@
+package com.mindmate.mindmate_server.global.config;
+
+import com.mindmate.mindmate_server.auth.util.JwtTokenProvider;
+import com.mindmate.mindmate_server.chat.domain.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 메시지 브로커 설정
+     */
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // topic -> 일대다 메시징을 위한 topic 기반 메시지 브로딩캐스팅
+        // queue -> 일대일 메시징을 위한 큐 기반 메시지 전달
+        // heartbeat -> 클라이언트-서버 간 연결 상태 확인 (10초)
+        config.enableSimpleBroker("/topic", "/queue")
+                .setTaskScheduler(heartBeatScheduler())
+                .setHeartbeatValue(new long[] {10000, 10000});
+
+        config.setApplicationDestinationPrefixes("/app"); // 클라이언트 메시지 전송 경로
+        config.setUserDestinationPrefix("/user"); // 특정 사용자에게 메시지 보낼 때 사용할 prefix
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS(); // WebSocket 엔드포인트
+    }
+
+    /**
+     * Websocket 전송 관련 설정
+     */
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
+        registration
+                .setSendTimeLimit(15 * 1000) // 메시지 전송 제한 시간 15초
+                .setSendBufferSizeLimit(512 * 1024) // 버퍼 크기 512KB
+                .setMessageSizeLimit(128 * 1024); // 메시지 크기 128KB
+    }
+
+    /**
+     * heartbeat 처리를 위한 스케줄러 설정
+     */
+    @Bean
+    public ThreadPoolTaskScheduler heartBeatScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1); // 단일 스레드
+        scheduler.setThreadNamePrefix("ws-heartbeat-");
+        return scheduler;
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                    String token = accessor.getFirstNativeHeader("Authorization");
+                    if (token != null && token.startsWith("Bearer ")) {
+                        String jwtToken = token.substring(7);
+                        Long userId = jwtTokenProvider.getUserIdFromToken(jwtToken);
+                        accessor.setUser(new UserPrincipal(userId));
+                    }
+                }
+                return message;
+            }
+        });
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/global/exception/ChatErrorCode.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/exception/ChatErrorCode.java
@@ -1,0 +1,44 @@
+package com.mindmate.mindmate_server.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatErrorCode implements ErrorCode {
+    // 채팅방 관련 오류
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다"),
+    CHAT_ROOM_CLOSED(HttpStatus.BAD_REQUEST, "이미 종료된 채팅방입니다"),
+    CHAT_ROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 채팅방에 접근 권한이 없습니다"),
+    CHAT_ROOM_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "채팅방 생성에 실패했습니다"),
+    CHAT_ROOM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 채팅방입니다"),
+
+    // 메시지 관련 오류
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "메시지를 찾을 수 없습니다"),
+    MESSAGE_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메시지 전송에 실패했습니다"),
+    MESSAGE_CONTENT_EMPTY(HttpStatus.BAD_REQUEST, "메시지 내용이 비어있습니다"),
+    MESSAGE_TOO_LONG(HttpStatus.BAD_REQUEST, "메시지 길이가 제한을 초과했습니다"),
+    MESSAGE_CONTAINS_INAPPROPRIATE_CONTENT(HttpStatus.BAD_REQUEST, "부적절한 내용이 포함되어 있습니다"),
+
+    // 사용자 참여 관련 오류
+    USER_ALREADY_IN_CHAT(HttpStatus.CONFLICT, "이미 채팅방에 참여 중입니다"),
+    USER_NOT_IN_CHAT(HttpStatus.FORBIDDEN, "채팅방에 참여하지 않은 사용자입니다"),
+    USER_BLOCKED(HttpStatus.FORBIDDEN, "차단된 사용자와는 채팅할 수 없습니다"),
+    INVALID_ROLE_FOR_CHAT(HttpStatus.BAD_REQUEST, "현재 역할로는 이 채팅에 참여할 수 없습니다"),
+
+    // 읽음 상태 관련 오류
+    READ_STATUS_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "읽음 상태 업데이트에 실패했습니다"),
+
+    // 연결 관련 오류
+    WEBSOCKET_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WebSocket 연결에 실패했습니다"),
+    REDIS_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 연결에 실패했습니다"),
+    KAFKA_CONNECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Kafka 연결에 실패했습니다"),
+
+    // 알림 관련 오류
+    NOTIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "알림 전송에 실패했습니다");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/mindmate/mindmate_server/global/service/FCMService.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/service/FCMService.java
@@ -10,27 +10,27 @@ import org.springframework.stereotype.Service;
 
 import java.util.Map;
 
-@Service
-@Slf4j
-@RequiredArgsConstructor
-public class FCMService {
-    private final FirebaseMessaging firebaseMessaging;
-
-    public void sendNotification(String token, String title, String body, Map<String, String> data) {
-        try {
-            Message message = Message.builder()
-                    .setToken(token)
-                    .setNotification(Notification.builder()
-                            .setTitle(title)
-                            .setBody(body)
-                            .build())
-                    .putAllData(data)
-                    .build();
-
-            String response = firebaseMessaging.send(message);
-            log.info("FCM notification sent successfully: {}", response);
-        } catch (FirebaseMessagingException e) {
-            log.error("Failed to send FCM notification", e);
-        }
-    }
-}
+//@Service
+//@Slf4j
+//@RequiredArgsConstructor
+//public class FCMService {
+//    private final FirebaseMessaging firebaseMessaging;
+//
+//    public void sendNotification(String token, String title, String body, Map<String, String> data) {
+//        try {
+//            Message message = Message.builder()
+//                    .setToken(token)
+//                    .setNotification(Notification.builder()
+//                            .setTitle(title)
+//                            .setBody(body)
+//                            .build())
+//                    .putAllData(data)
+//                    .build();
+//
+//            String response = firebaseMessaging.send(message);
+//            log.info("FCM notification sent successfully: {}", response);
+//        } catch (FirebaseMessagingException e) {
+//            log.error("Failed to send FCM notification", e);
+//        }
+//    }
+//}

--- a/src/main/java/com/mindmate/mindmate_server/global/service/FCMService.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/service/FCMService.java
@@ -1,0 +1,36 @@
+package com.mindmate.mindmate_server.global.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FCMService {
+    private final FirebaseMessaging firebaseMessaging;
+
+    public void sendNotification(String token, String title, String body, Map<String, String> data) {
+        try {
+            Message message = Message.builder()
+                    .setToken(token)
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .putAllData(data)
+                    .build();
+
+            String response = firebaseMessaging.send(message);
+            log.info("FCM notification sent successfully: {}", response);
+        } catch (FirebaseMessagingException e) {
+            log.error("Failed to send FCM notification", e);
+        }
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/global/service/FCMTokenService.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/service/FCMTokenService.java
@@ -1,0 +1,34 @@
+package com.mindmate.mindmate_server.global.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FCMTokenService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String FCM_TOKEN_PREFIX = "FCM:";
+    private static final long FCM_TOKEN_EXPIRY = 60 * 24 * 7;
+
+    public void saveUserFCMToken(Long userId, String fcmToken) {
+        String key = FCM_TOKEN_PREFIX + userId;
+        redisTemplate.opsForValue().set(key, fcmToken, FCM_TOKEN_EXPIRY, TimeUnit.MINUTES);
+        log.info("FCM token saved for user: {}", userId);
+    }
+
+    public String getUserFCMToken(Long userId) {
+        String key = FCM_TOKEN_PREFIX + userId;
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void removeUserFCMToken(long userId) {
+        String key = FCM_TOKEN_PREFIX + userId;
+        redisTemplate.delete(key);
+        log.info("FCM token removed for user: {}", userId);
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/global/util/RedisKeyManager.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/util/RedisKeyManager.java
@@ -1,0 +1,31 @@
+package com.mindmate.mindmate_server.global.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisKeyManager {
+    // 사용자 상태 관련 키
+    public String getUserStatusKey(Long userId) {
+        return "user:status:" + userId;
+    }
+
+    // 읽지 않은 메시지 카운트 관련 키
+    public String getUnreadCountKey(Long roomId, Long userId) {
+        return "chat:room:" + roomId + ":unread:" + userId;
+    }
+
+    // 채팅방 채널 키
+    public String getChatRoomChannel(Long roomId) {
+        return "chat:room:" + roomId;
+    }
+
+    // 사용자 상태 채널 키
+    public String getUserStatusChannel(Long userId) {
+        return "user:status:" + userId;
+    }
+
+    // 읽음 상태 키
+    public String getReadStatusKey(Long roomId, Long userId) {
+        return "chat:room:" + roomId + ":read:" + userId;
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/user/controller/ProfileController.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/controller/ProfileController.java
@@ -1,5 +1,6 @@
 package com.mindmate.mindmate_server.user.controller;
 
+import com.mindmate.mindmate_server.chat.domain.UserPrincipal;
 import com.mindmate.mindmate_server.user.domain.CounselingField;
 import com.mindmate.mindmate_server.user.domain.CounselingStyle;
 import com.mindmate.mindmate_server.user.domain.RoleType;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
@@ -40,47 +42,56 @@ public class ProfileController {
 
     @Operation(summary = "리스너 프로필 생성", description = "리스너 프로필을 생성합니다.")
     @PostMapping("/listener")
-    public ResponseEntity<ProfileResponse> createListenerProfile(@Valid @RequestBody ListenerProfileRequest request) {
-        ProfileResponse response = profileService.createListenerProfile(request);
+    public ResponseEntity<ProfileResponse> createListenerProfile(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody ListenerProfileRequest request) {
+        ProfileResponse response = profileService.createListenerProfile(principal.getUserId(), request);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "스피커 프로필 생성", description = "스피커 프로필을 생성합니다.")
     @PostMapping("/speaker")
-    public ResponseEntity<ProfileResponse> createSpeakerProfile(@Valid @RequestBody SpeakerProfileRequest request) {
-        ProfileResponse response = profileService.createSpeakerProfile(request);
+    public ResponseEntity<ProfileResponse> createSpeakerProfile(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody SpeakerProfileRequest request) {
+        ProfileResponse response = profileService.createSpeakerProfile(principal.getUserId(), request);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "리스너 프로필 수정", description = "리스너의 프로필을 수정합니다.")
     @PutMapping("/listener")
     public ResponseEntity<ListenerProfileResponse> updateListenerProfile(
+            @AuthenticationPrincipal UserPrincipal principal,
             @Valid @RequestBody ListenerProfileUpdateRequest request) {
-        User currentUser = userService.getCurrentUser();
-        return ResponseEntity.ok(profileService.updateListenerProfile(currentUser.getListenerProfile().getId(), request));
+        User user = userService.findUserById(principal.getUserId());
+        return ResponseEntity.ok(profileService.updateListenerProfile(user.getListenerProfile().getId(), request));
     }
 
     @Operation(summary = "스피커 프로필 수정", description = "스피커 프로필을 수정합니다.")
     @PutMapping("/speaker")
     public ResponseEntity<SpeakerProfileResponse> updateSpeakerProfile(
+            @AuthenticationPrincipal UserPrincipal principal,
             @Valid @RequestBody SpeakerProfileUpdateRequest request) {
-        User currentUser = userService.getCurrentUser();
-        return ResponseEntity.ok(profileService.updateSpeakerProfile(currentUser.getSpeakerProfile().getId(), request));
+        User user = userService.findUserById(principal.getUserId());
+        return ResponseEntity.ok(profileService.updateSpeakerProfile(user.getSpeakerProfile().getId(), request));
     }
 
     /* 이후에 여러 자격을 가질 때를 고려해야함*/
     @Operation(summary = "리스너 자격 수정", description = "리스너의 자격을 수정합니다.")
     @PutMapping("/listener/certification")
     public ResponseEntity<ListenerProfileResponse> updateListenerCertification(
+            @AuthenticationPrincipal UserPrincipal principal,
             @Valid @RequestBody CertificationUpdateRequest request) {
-        User currentUser = userService.getCurrentUser();
-        return ResponseEntity.ok(profileService.updateListenerCertification(currentUser.getListenerProfile().getId(), request));
+        User user = userService.findUserById(principal.getUserId());
+        return ResponseEntity.ok(profileService.updateListenerCertification(user.getListenerProfile().getId(), request));
     }
 
     @Operation(summary = "역할 전환", description = "리스너/스피커 역할을 전환합니다.")
     @PostMapping("/switch-role")
-    public ResponseEntity<?> switchRole(@RequestParam RoleType targetRole) {
-        ProfileStatusResponse response = profileService.switchRole(targetRole);
+    public ResponseEntity<?> switchRole(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam RoleType targetRole) {
+        ProfileStatusResponse response = profileService.switchRole(principal.getUserId(), targetRole);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/ListenerProfile.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/ListenerProfile.java
@@ -1,5 +1,6 @@
 package com.mindmate.mindmate_server.user.domain;
 
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
 import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -17,12 +19,6 @@ import java.util.Set;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ListenerProfile extends BaseTimeEntity {
-    /**
-     * 향후 추가 사항
-     * 1. 경력 인증 관련 필드
-     * 2. available_time 관리 어떻게 할지
-     */
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -47,6 +43,9 @@ public class ListenerProfile extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToMany(mappedBy = "listener", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatRoom> chatRooms = new ArrayList<>();
 
     private String certificationUrl;
 

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/SpeakerProfile.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/SpeakerProfile.java
@@ -1,11 +1,15 @@
 package com.mindmate.mindmate_server.user.domain;
 
+import com.mindmate.mindmate_server.chat.domain.ChatRoom;
 import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "speaker_profiles")
@@ -31,6 +35,9 @@ public class SpeakerProfile extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToMany(mappedBy = "speaker", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatRoom> chatRooms = new ArrayList<>();
 
     @Builder
     public SpeakerProfile(User user, String nickname, String profileImage, CounselingStyle preferredCounselingStyle) {

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = {"listenerProfile", "speakerProfile"})
+@ToString(exclude = {"listenerProfile", "speakerProfile", "sentMessages"})
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
@@ -1,12 +1,15 @@
 package com.mindmate.mindmate_server.user.domain;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.mindmate.mindmate_server.chat.domain.ChatMessage;
 import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -47,6 +50,9 @@ public class User extends BaseTimeEntity {
 
     @OneToOne(mappedBy = "user")
     private SpeakerProfile speakerProfile;
+
+    @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL)
+    private List<ChatMessage> sentMessages = new ArrayList<>();
 
     @Builder
     public User(String email, String password, RoleType role) {

--- a/src/main/java/com/mindmate/mindmate_server/user/service/ProfileService.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/ProfileService.java
@@ -9,9 +9,9 @@ public interface ProfileService {
     ListenerProfileResponse getListenerProfile(Long profileId);
     SpeakerProfileResponse getSpeakerProfile(Long profileId);
 
-    ProfileResponse createListenerProfile(ListenerProfileRequest request);
+    ProfileResponse createListenerProfile(Long userId, ListenerProfileRequest request);
 
-    ProfileResponse createSpeakerProfile(SpeakerProfileRequest request);
+    ProfileResponse createSpeakerProfile(Long userId, SpeakerProfileRequest request);
 
     ListenerProfileResponse updateListenerProfile(Long profileId, ListenerProfileUpdateRequest request);
 
@@ -19,7 +19,7 @@ public interface ProfileService {
 
     ListenerProfileResponse updateListenerCertification(Long profileId, CertificationUpdateRequest request);
 
-    ProfileStatusResponse switchRole(RoleType targetRole);
+    ProfileStatusResponse switchRole(Long userId, RoleType targetRole);
 
     void updateAverageRating(Long profileId, RoleType roleType, Float newRating);
 

--- a/src/main/java/com/mindmate/mindmate_server/user/service/ProfileServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/ProfileServiceImpl.java
@@ -93,8 +93,8 @@ public class ProfileServiceImpl implements ProfileService {
      * 프로필 저장 + 사용자 currentRole 수정
      */
     @Override
-    public ProfileResponse createListenerProfile(ListenerProfileRequest request) {
-        User user = getCurrentUser();
+    public ProfileResponse createListenerProfile(Long userId, ListenerProfileRequest request) {
+        User user = userService.findUserById(userId);
         ListenerProfile profile = createListenerProfileFromRequest(user, request);
         return saveProfileAndUpdateRole(profile, RoleType.ROLE_LISTENER);
     }
@@ -105,8 +105,8 @@ public class ProfileServiceImpl implements ProfileService {
      * 프로필 저장 + 사용자 currentRole 수정
      */
     @Override
-    public ProfileResponse createSpeakerProfile(SpeakerProfileRequest request) {
-        User user = getCurrentUser();
+    public ProfileResponse createSpeakerProfile(Long userId, SpeakerProfileRequest request) {
+        User user = userService.findUserById(userId);
         SpeakerProfile profile = createSpeakerProfileFromRequest(user, request);
 
         return saveProfileAndUpdateRole(profile, RoleType.ROLE_SPEAKER);
@@ -118,8 +118,8 @@ public class ProfileServiceImpl implements ProfileService {
      * user currentRole 업데이트
      */
     @Override
-    public ProfileStatusResponse switchRole(RoleType targetRole) {
-        User user = getCurrentUser();
+    public ProfileStatusResponse switchRole(Long userId, RoleType targetRole) {
+        User user = userService.findUserById(userId);
         validateRoleTransition(user.getCurrentRole(), targetRole);
 
         boolean hasListenerProfile = user.getListenerProfile() != null;

--- a/src/main/java/com/mindmate/mindmate_server/user/service/UserService.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/UserService.java
@@ -3,7 +3,7 @@ package com.mindmate.mindmate_server.user.service;
 import com.mindmate.mindmate_server.user.domain.User;
 
 public interface UserService {
-    User getCurrentUser();
+//    User getCurrentUser();
 
     User findUserById(Long userId);
 

--- a/src/main/java/com/mindmate/mindmate_server/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/UserServiceImpl.java
@@ -13,12 +13,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
-    private final SecurityUtil securityUtil;
+//    private final SecurityUtil securityUtil;
 
-    @Override
-    public User getCurrentUser() {
-        return securityUtil.getCurrentUser();
-    }
+//    @Override
+//    public User getCurrentUser() {
+//        return securityUtil.getCurrentUser();
+//    }
 
     @Override
     public User findUserById(Long userId) {

--- a/src/main/resources/templates/websocket-test.html
+++ b/src/main/resources/templates/websocket-test.html
@@ -1,0 +1,590 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>WebSocket 채팅 테스트</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .container { max-width: 1000px; margin: 0 auto; }
+        .form-group { margin-bottom: 15px; }
+        .form-group label { display: block; margin-bottom: 5px; }
+        .form-group input, .form-group textarea { width: 100%; padding: 8px; box-sizing: border-box; }
+        button { padding: 8px 15px; margin-right: 10px; cursor: pointer; }
+        #log { height: 300px; overflow-y: scroll; border: 1px solid #ccc; padding: 10px; margin-top: 20px; background-color: #f5f5f5; }
+        .success { color: green; }
+        .error { color: red; }
+        .info { color: blue; }
+        .warning { color: orange; }
+        .flex-container { display: flex; justify-content: space-between; }
+        .col { flex: 1; margin: 0 10px; }
+        .message-container { border: 1px solid #ddd; padding: 10px; margin-bottom: 10px; border-radius: 5px; }
+        .message-sender { font-weight: bold; }
+        .message-time { font-size: 0.8em; color: #666; }
+        .message-content { margin-top: 5px; }
+        .read-status { font-size: 0.8em; color: #666; text-align: right; }
+        .online-status { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 5px; }
+        .online { background-color: green; }
+        .offline { background-color: gray; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>WebSocket 채팅 테스트</h1>
+    
+    <div class="flex-container">
+        <div class="col">
+            <div class="form-group">
+                <label for="token">JWT 토큰:</label>
+                <input type="text" id="token" placeholder="JWT 토큰" value="여기에 JWT 토큰 입력">
+            </div>
+            
+            <div>
+                <button onclick="connect()">연결</button>
+                <button onclick="disconnect()">연결 해제</button>
+            </div>
+            
+            <div class="form-group" style="margin-top: 20px;">
+                <label for="roomId">채팅방 ID:</label>
+                <input type="text" id="roomId" placeholder="채팅방 ID" value="1">
+                <button onclick="subscribe()">채팅방 입장</button>
+                <button onclick="unsubscribe()">채팅방 퇴장</button>
+            </div>
+            
+            <div class="form-group">
+                <label for="message">메시지:</label>
+                <textarea id="message" placeholder="보낼 메시지를 입력하세요" rows="3"></textarea>
+                <button onclick="sendMessage()">전송</button>
+            </div>
+            
+            <div class="form-group">
+                <button onclick="markAsRead()">읽음 처리</button>
+                <button onclick="fetchMessages()">메시지 조회 (REST)</button>
+                <button onclick="fetchChatRooms()">채팅방 목록 조회</button>
+            </div>
+        </div>
+        
+        <div class="col">
+            <h3>채팅방 정보</h3>
+            <div id="roomInfo">
+                <p>채팅방: <span id="currentRoomDisplay">없음</span></p>
+                <p>참가자 상태:</p>
+                <ul id="participantStatus">
+                    <li>참가자 정보가 없습니다.</li>
+                </ul>
+                <p>읽지 않은 메시지: <span id="unreadCount">0</span></p>
+            </div>
+            
+            <h3>메시지</h3>
+            <div id="messages"></div>
+        </div>
+    </div>
+    
+    <h3>로그</h3>
+    <div id="log"></div>
+</div>
+
+<script>
+    let stompClient = null;
+    let currentRoomId = null;
+    let subscriptions = {};
+    let userId = null;
+    let messages = [];
+    let participants = {};
+    let baseUrl = 'http://localhost:8080';
+    
+    // 1. 연결 및 기본 설정
+    function connect() {
+        const token = document.getElementById('token').value;
+        if (!token) {
+            logMessage("토큰을 입력해주세요", "error");
+            return;
+        }
+
+        // SockJS 연결 생성
+        const socket = new SockJS(baseUrl + '/ws');
+        stompClient = Stomp.over(socket);
+        
+        // 디버그 로그 비활성화 (필요시 활성화)
+        stompClient.debug = null;
+        
+        // 연결 시도
+        logMessage("연결 시도 중...", "info");
+        stompClient.connect(
+            { 'Authorization': 'Bearer ' + token },
+            function(frame) {
+                logMessage('연결 성공: ' + frame, "success");
+                
+                // JWT 토큰에서 사용자 ID 추출 (실제로는 서버에서 처리)
+                try {
+                    const base64Url = token.split('.')[1];
+                    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+                    const jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
+                        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+                    }).join(''));
+                    const payload = JSON.parse(jsonPayload);
+                    userId = payload.userId || payload.sub;
+                    logMessage(`사용자 ID: ${userId}`, "info");
+                } catch (e) {
+                    logMessage('토큰에서 사용자 ID를 추출할 수 없습니다: ' + e, "warning");
+                }
+                
+                // 개인 알림 구독
+                subscriptions['notification'] = stompClient.subscribe('/user/queue/notification', function(notification) {
+                    const notificationData = JSON.parse(notification.body);
+                    logMessage('알림 수신: ' + notification.body, "info");
+                    handleNotification(notificationData);
+                });
+                
+                // 개인 읽지 않은 메시지 카운트 구독
+                subscriptions['unread'] = stompClient.subscribe('/user/queue/unread', function(unread) {
+                    const unreadData = JSON.parse(unread.body);
+                    logMessage('읽지 않은 메시지 업데이트: ' + unread.body, "info");
+                    updateUnreadCount(unreadData);
+                });
+                
+                // 상태 업데이트 전송
+                stompClient.send('/app/presence', {},
+                    JSON.stringify({status: 'ONLINE', activeRoomId: null})
+                );
+                logMessage("온라인 상태로 업데이트됨", "success");
+            },
+            function(error) {
+                logMessage('연결 오류: ' + error, "error");
+            }
+        );
+    }
+    
+    // 2. 연결 해제
+    function disconnect() {
+        if (stompClient !== null) {
+            // 연결 해제 전 상태 업데이트
+            try {
+                stompClient.send('/app/presence', {},
+                    JSON.stringify({status: 'OFFLINE', activeRoomId: null})
+                );
+            } catch (e) {
+                logMessage('상태 업데이트 실패: ' + e, "error");
+            }
+            
+            // 모든 구독 해제
+            Object.values(subscriptions).forEach(sub => {
+                try {
+                    sub.unsubscribe();
+                } catch (e) {}
+            });
+            subscriptions = {};
+            
+            // 연결 해제
+            stompClient.disconnect();
+            logMessage('연결이 해제되었습니다', "info");
+            stompClient = null;
+            currentRoomId = null;
+            updateRoomDisplay();
+        }
+    }
+    
+    // 3. 채팅방 구독 (입장)
+    function subscribe() {
+        if (!stompClient) {
+            logMessage("먼저 연결을 해주세요", "error");
+            return;
+        }
+        
+        currentRoomId = document.getElementById('roomId').value;
+        if (!currentRoomId) {
+            logMessage("채팅방 ID를 입력해주세요", "error");
+            return;
+        }
+        
+        // 이미 구독 중인 경우 해제
+        unsubscribeRoom(currentRoomId);
+        
+        // 새로운 구독 생성
+        logMessage(`채팅방 ${currentRoomId} 구독 중...`, "info");
+        
+        // 채팅 메시지 구독
+        subscriptions[`room_${currentRoomId}`] = stompClient.subscribe(
+            '/topic/chat.room.' + currentRoomId,
+            function(message) {
+                const messageData = JSON.parse(message.body);
+                logMessage(`메시지 수신 [${currentRoomId}]: ${JSON.stringify(messageData)}`, "success");
+                handleIncomingMessage(messageData);
+            }
+        );
+        
+        // 읽음 상태 구독
+        subscriptions[`read_${currentRoomId}`] = stompClient.subscribe(
+            '/topic/chat.room.' + currentRoomId + '.read',
+            function(readStatus) {
+                const readData = JSON.parse(readStatus.body);
+                logMessage(`읽음 상태 업데이트 [${currentRoomId}]: ${JSON.stringify(readData)}`, "info");
+                updateReadStatus(readData);
+            }
+        );
+        
+        // 상태 업데이트 (현재 활성 채팅방)
+        stompClient.send('/app/presence', {},
+            JSON.stringify({status: 'ONLINE', activeRoomId: currentRoomId})
+        );
+        
+        // 읽음 처리
+        markAsRead();
+        
+        // 메시지 조회 (REST API)
+        fetchMessages();
+        
+        updateRoomDisplay();
+        logMessage(`채팅방 ${currentRoomId} 구독 완료`, "success");
+    }
+    
+    // 4. 채팅방 구독 해제 (퇴장)
+    function unsubscribe() {
+        if (!currentRoomId) {
+            logMessage("현재 구독 중인 채팅방이 없습니다", "warning");
+            return;
+        }
+        
+        unsubscribeRoom(currentRoomId);
+        
+        // 상태 업데이트 (활성 채팅방 없음)
+        if (stompClient) {
+            stompClient.send('/app/presence', {},
+                JSON.stringify({status: 'ONLINE', activeRoomId: null})
+            );
+        }
+        
+        currentRoomId = null;
+        updateRoomDisplay();
+        document.getElementById('messages').innerHTML = '';
+        logMessage("채팅방에서 퇴장했습니다", "info");
+    }
+    
+    function unsubscribeRoom(roomId) {
+        // 채팅 메시지 구독 해제
+        if (subscriptions[`room_${roomId}`]) {
+            try {
+                subscriptions[`room_${roomId}`].unsubscribe();
+                delete subscriptions[`room_${roomId}`];
+            } catch (e) {
+                logMessage(`구독 해제 오류: ${e}`, "error");
+            }
+        }
+        
+        // 읽음 상태 구독 해제
+        if (subscriptions[`read_${roomId}`]) {
+            try {
+                subscriptions[`read_${roomId}`].unsubscribe();
+                delete subscriptions[`read_${roomId}`];
+            } catch (e) {
+                logMessage(`읽음 상태 구독 해제 오류: ${e}`, "error");
+            }
+        }
+    }
+    
+    // 5. 메시지 전송
+    function sendMessage() {
+        if (!stompClient) {
+            logMessage("먼저 연결을 해주세요", "error");
+            return;
+        }
+        
+        if (!currentRoomId) {
+            logMessage("먼저 채팅방을 구독해주세요", "error");
+            return;
+        }
+        
+        const messageContent = document.getElementById('message').value;
+        if (!messageContent) {
+            logMessage("메시지를 입력해주세요", "error");
+            return;
+        }
+        
+        const chatMessage = {
+            roomId: currentRoomId,
+            content: messageContent,
+            type: 'TEXT'  // 메시지 타입 (TEXT, IMAGE 등)
+        };
+        
+        logMessage(`메시지 전송 중: ${JSON.stringify(chatMessage)}`, "info");
+        stompClient.send('/app/chat.send', {}, JSON.stringify(chatMessage));
+        document.getElementById('message').value = '';
+    }
+    
+    // 6. 읽음 처리
+    function markAsRead() {
+        if (!stompClient || !currentRoomId) {
+            logMessage("채팅방에 입장한 상태에서만 읽음 처리가 가능합니다", "warning");
+            return;
+        }
+        
+        const readRequest = {
+            roomId: currentRoomId
+        };
+        
+        stompClient.send('/app/chat.read', {}, JSON.stringify(readRequest));
+        logMessage(`채팅방 ${currentRoomId}의 메시지를 읽음 처리했습니다`, "info");
+    }
+    
+    // 7. REST API를 통한 메시지 조회
+function fetchMessages() {
+    if (!currentRoomId) {
+        logMessage("먼저 채팅방을 선택해주세요", "warning");
+        return;
+    }
+    
+    const token = document.getElementById('token').value;
+    if (!token) {
+        logMessage("토큰을 입력해주세요", "error");
+        return;
+    }
+    
+    logMessage(`채팅방 ${currentRoomId}의 메시지를 조회합니다...`, "info");
+    
+    fetch(`${baseUrl}/api/chat/rooms/${currentRoomId}/messages?page=0&size=20`, {
+        method: 'GET',
+        headers: {
+            'Authorization': 'Bearer ' + token,
+            'Content-Type': 'application/json'
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('메시지 조회 실패: ' + response.status);
+        }
+        return response.json();
+    })
+    .then(data => {
+        logMessage(`메시지 조회 성공: ${data.messages.length}개의 메시지`, "success");
+        displayMessages(data);
+        updateParticipantStatus(data);
+    })
+    .catch(error => {
+        logMessage('메시지 조회 오류: ' + error.message, "error");
+    });
+}
+
+// 8. REST API를 통한 채팅방 목록 조회
+function fetchChatRooms() {
+    const token = document.getElementById('token').value;
+    if (!token) {
+        logMessage("토큰을 입력해주세요", "error");
+        return;
+    }
+    
+    logMessage("채팅방 목록을 조회합니다...", "info");
+    
+    fetch(`${baseUrl}/api/chat/rooms?page=0&size=10`, {
+        method: 'GET',
+        headers: {
+            'Authorization': 'Bearer ' + token,
+            'Content-Type': 'application/json'
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('채팅방 목록 조회 실패: ' + response.status);
+        }
+        return response.json();
+    })
+    .then(data => {
+        logMessage(`채팅방 목록 조회 성공: ${data.content.length}개의 채팅방`, "success");
+        displayChatRooms(data);
+    })
+    .catch(error => {
+        logMessage('채팅방 목록 조회 오류: ' + error.message, "error");
+    });
+}
+
+// 수신된 메시지 처리
+function handleIncomingMessage(message) {
+    // 메시지 타입에 따른 처리
+    if (message.type === 'READ_STATUS') {
+        // 읽음 상태 업데이트
+        updateReadStatus(message);
+    } else if (message.type === 'CONTENT_FILTERED') {
+        // 필터링된 메시지 처리
+        logMessage(`메시지 ID ${message.messageId}가 필터링되었습니다: ${message.content}`, "warning");
+    } else {
+        // 일반 메시지 처리
+        addMessageToDisplay(message);
+    }
+}
+
+// 알림 처리
+function handleNotification(notification) {
+    // 알림 타입에 따른 처리
+    if (notification.type === 'NEW_MESSAGE') {
+        // 새 메시지 알림
+        logMessage(`새 메시지 알림: 채팅방 ${notification.roomId}에 새 메시지가 있습니다`, "info");
+    } else if (notification.type === 'ROOM_STATUS') {
+        // 채팅방 상태 변경 알림
+        logMessage(`채팅방 상태 변경: 채팅방 ${notification.roomId}의 상태가 ${notification.status}로 변경되었습니다`, "info");
+    }
+}
+
+// 읽지 않은 메시지 수 업데이트
+function updateUnreadCount(unreadData) {
+    const roomId = unreadData.roomId;
+    const count = unreadData.unreadCount;
+    
+    if (roomId === currentRoomId) {
+        document.getElementById('unreadCount').textContent = count;
+    }
+    
+    logMessage(`채팅방 ${roomId}의 읽지 않은 메시지: ${count}개`, "info");
+}
+
+// 읽음 상태 업데이트
+function updateReadStatus(readData) {
+    const messageElements = document.querySelectorAll('.message-container');
+    messageElements.forEach(element => {
+        const readStatusElement = element.querySelector('.read-status');
+        if (readStatusElement) {
+            readStatusElement.textContent = '읽음';
+        }
+    });
+    
+    logMessage(`사용자 ${readData.userId}가 메시지를 읽었습니다`, "info");
+}
+
+// 메시지 화면에 표시
+function displayMessages(data) {
+    const messagesDiv = document.getElementById('messages');
+    messagesDiv.innerHTML = '';
+    
+    // 메시지 역순으로 정렬 (최신 메시지가 아래에 표시)
+    const sortedMessages = data.messages.sort((a, b) =>
+        new Date(a.createdAt) - new Date(b.createdAt)
+    );
+    
+    sortedMessages.forEach(message => {
+        addMessageToDisplay(message);
+    });
+    
+    // 스크롤을 맨 아래로 이동
+    messagesDiv.scrollTop = messagesDiv.scrollHeight;
+}
+
+// 단일 메시지 화면에 추가
+function addMessageToDisplay(message) {
+    const messagesDiv = document.getElementById('messages');
+    const messageDiv = document.createElement('div');
+    messageDiv.className = 'message-container';
+    
+    // 메시지 발신자가 현재 사용자인지 확인
+    const isMine = message.senderId == userId;
+    if (isMine) {
+        messageDiv.style.backgroundColor = '#e6f7ff';
+        messageDiv.style.marginLeft = '20%';
+    }
+    
+    const senderDiv = document.createElement('div');
+    senderDiv.className = 'message-sender';
+    senderDiv.textContent = isMine ? '나' : `사용자 ${message.senderId} (${message.senderRole})`;
+    
+    const timeDiv = document.createElement('div');
+    timeDiv.className = 'message-time';
+    const messageTime = new Date(message.createdAt);
+    timeDiv.textContent = messageTime.toLocaleString();
+    
+    const contentDiv = document.createElement('div');
+    contentDiv.className = 'message-content';
+    contentDiv.textContent = message.content;
+    
+    const readStatusDiv = document.createElement('div');
+    readStatusDiv.className = 'read-status';
+    readStatusDiv.textContent = '읽지 않음';  // 기본값
+    
+    messageDiv.appendChild(senderDiv);
+    messageDiv.appendChild(timeDiv);
+    messageDiv.appendChild(contentDiv);
+    messageDiv.appendChild(readStatusDiv);
+    
+    messagesDiv.appendChild(messageDiv);
+    messagesDiv.scrollTop = messagesDiv.scrollHeight;
+}
+
+// 채팅방 목록 표시
+function displayChatRooms(data) {
+    const logDiv = document.getElementById('log');
+    
+    // 채팅방 목록 헤더 추가
+    const header = document.createElement('p');
+    header.style.fontWeight = 'bold';
+    header.textContent = '=== 채팅방 목록 ===';
+    logDiv.appendChild(header);
+    
+    // 각 채팅방 정보 추가
+    data.content.forEach(room => {
+        const roomInfo = document.createElement('p');
+        roomInfo.innerHTML = `채팅방 ID: ${room.id} | 마지막 메시지: ${room.lastMessageTime || '없음'} | 읽지 않은 메시지: ${room.unreadCount || 0}`;
+        logDiv.appendChild(roomInfo);
+        
+        // 채팅방 입장 버튼 추가
+        const enterButton = document.createElement('button');
+        enterButton.textContent = '입장';
+        enterButton.style.marginLeft = '10px';
+        enterButton.onclick = function() {
+            document.getElementById('roomId').value = room.id;
+            subscribe();
+        };
+        roomInfo.appendChild(enterButton);
+    });
+    
+    logDiv.scrollTop = logDiv.scrollHeight;
+}
+
+// 참가자 상태 업데이트
+function updateParticipantStatus(data) {
+    const participantsList = document.getElementById('participantStatus');
+    participantsList.innerHTML = '';
+    
+    if (data.listener) {
+        const listenerItem = document.createElement('li');
+        const statusSpan = document.createElement('span');
+        statusSpan.className = 'online-status ' + (data.listener.online ? 'online' : 'offline');
+        listenerItem.appendChild(statusSpan);
+        listenerItem.appendChild(document.createTextNode(
+            `리스너 (ID: ${data.listener.userId}): ${data.listener.online ? '온라인' : '오프라인'}`
+        ));
+        participantsList.appendChild(listenerItem);
+    }
+    
+    if (data.speaker) {
+        const speakerItem = document.createElement('li');
+        const statusSpan = document.createElement('span');
+        statusSpan.className = 'online-status ' + (data.speaker.online ? 'online' : 'offline');
+        speakerItem.appendChild(statusSpan);
+        speakerItem.appendChild(document.createTextNode(
+            `스피커 (ID: ${data.speaker.userId}): ${data.speaker.online ? '온라인' : '오프라인'}`
+        ));
+        participantsList.appendChild(speakerItem);
+    }
+}
+
+// 현재 채팅방 표시 업데이트
+function updateRoomDisplay() {
+    document.getElementById('currentRoomDisplay').textContent =
+        currentRoomId ? currentRoomId : '없음';
+}
+
+// 로그 메시지 표시
+function logMessage(message, type) {
+    const logDiv = document.getElementById('log');
+    const p = document.createElement('p');
+    p.style.margin = '5px 0';
+    p.className = type || '';
+    
+    // 타임스탬프 추가
+    const now = new Date();
+    const timestamp = `${now.getHours()}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`;
+    
+    p.textContent = `[${timestamp}] ${message}`;
+    logDiv.appendChild(p);
+    logDiv.scrollTop = logDiv.scrollHeight;
+}
+
+</script> </body> </html> ```
+


### PR DESCRIPTION
## 🛰️ Issue Number
#13 

## 🪐 작업 내용
1. 채팅 관련 엔티티 추가
2. Redis, Kafka, Websocket config 설정
3. 관련 에러/DTO 추가
4. 채팅 관련 kafka consumer 설정
5. 채팅 로직 (채팅방/메시지/참여자(
6. securityUtil 변경

## 😎 해결하지 못한 거
1. 채팅방 온라인/오프라인 여부 제대로 동작 안함
2. 사용자 메시지 읽음/안읽음 처리 -> 1번 문제 때문에
3. 알림 서비스 추가 안함
4. 채팅 메시지/채팅방 조회 캐싱 적용 안함
5. 채팅방 종료 관련 로직 안함
7. 전체적인 redis 값 관리가 명확하지 않음


<img width="1276" alt="스크린샷 2025-03-04 145758" src="https://github.com/user-attachments/assets/665ac0ee-67e6-4cbb-80f0-095a76180640" />
일단 gpt가 만들어준 html 파일로 테스트 해보는데 이상해요.. 프론트 코드 문제인지 백엔드 문제인지 한 번 테스트 코드 진행하면서 알아보겠습니다