### PR TITLE
[Feat #14] 매칭 관련 로직

### DIFF
--- a/src/main/java/com/mindmate/mindmate_server/global/config/KafkaConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/KafkaConfig.java
@@ -1,0 +1,74 @@
+package com.mindmate.mindmate_server.global.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ContainerProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                org.apache.kafka.common.serialization.StringSerializer.class);
+        props.put(org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                org.apache.kafka.common.serialization.StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, "mindmate-matching");
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                org.apache.kafka.common.serialization.StringDeserializer.class);
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                org.apache.kafka.common.serialization.StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        return factory;
+    }
+
+    @Bean
+    public NewTopic matchingEventsTopic() {
+        return TopicBuilder.name("matching-events")
+                .partitions(3)
+                .replicas(1)
+                .compact()
+                .build();
+    }
+
+    @Bean
+    public NewTopic matchingQueueTopic() {
+        return TopicBuilder.name("matching-queue")
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+
+    // 알림 토픽?
+}

--- a/src/main/java/com/mindmate/mindmate_server/global/config/KafkaConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/KafkaConfig.java
@@ -31,7 +31,7 @@ public class KafkaConfig {
     public ConsumerFactory<String, String> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, "mindmate-matching");
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, "mindmate-group");
         props.put(org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
                 org.apache.kafka.common.serialization.StringDeserializer.class);
         props.put(org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,

--- a/src/main/java/com/mindmate/mindmate_server/global/exception/MatchingErrorCode.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/exception/MatchingErrorCode.java
@@ -1,0 +1,15 @@
+package com.mindmate.mindmate_server.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MatchingErrorCode implements ErrorCode {
+    MATCHING_NOT_FOUND(HttpStatus.NOT_FOUND, "매칭을 찾을 수 없습니다."),
+    INVALID_MATCHING_STATUS(HttpStatus.FORBIDDEN, "해당 상태에서 진행할 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/mindmate/mindmate_server/global/exception/MatchingErrorCode.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/exception/MatchingErrorCode.java
@@ -8,7 +8,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MatchingErrorCode implements ErrorCode {
     MATCHING_NOT_FOUND(HttpStatus.NOT_FOUND, "매칭을 찾을 수 없습니다."),
-    INVALID_MATCHING_STATUS(HttpStatus.FORBIDDEN, "해당 상태에서 진행할 수 없습니다.");
+    INVALID_MATCHING_STATUS(HttpStatus.BAD_REQUEST, "해당 상태에서 진행할 수 없습니다."),
+    INVALID_WAITING_QUEUE(HttpStatus.BAD_REQUEST, "하나의 프로필로만 대기 가능합니다."),
+    USER_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "해당 사용자와의 상담이 불가능합니다."),
+    USER_NOT_AUTHORIZED(HttpStatus.BAD_REQUEST, "해당 매칭의 사용자가 아닙니다."),
+    LIMIT_EXCEED(HttpStatus.BAD_REQUEST, "하루 최대 최소/거절 횟수를 초과하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/mindmate/mindmate_server/matching/controller/MatchingController.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/controller/MatchingController.java
@@ -1,0 +1,97 @@
+package com.mindmate.mindmate_server.matching.controller;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import com.mindmate.mindmate_server.matching.dto.*;
+import com.mindmate.mindmate_server.matching.service.MatchingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/matching")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Matching", description = "매칭 관련 API")
+public class MatchingController {
+    private final MatchingService matchingService;
+
+    @PostMapping("/auto/random")
+    @Operation(summary = "자동 랜덤 매칭 요청", description = "자동 랜덤 매칭을 요청합니다.")
+    public ResponseEntity<MatchingResponse> requestAutoRandomMatch(
+            @Valid @RequestBody AutoRandomMatchRequest request) {
+
+        MatchingResponse response = matchingService.autoRandomMatch(
+                request.getProfileId(), request.getInitiatorType());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/auto/format")
+    @Operation(summary = "자동 형식 매칭 요청", description = "특정 조건에 맞는 자동 매칭을 요청합니다.")
+    public ResponseEntity<MatchingResponse> requestAutoFormatMatch(
+            @Valid @RequestBody AutoFormatMatchRequest request) {
+
+        MatchingResponse response = matchingService.autoFormatMatch(
+                request.getProfileId(), request.getInitiatorType(),
+                request.getRequestedFields(), request.getPreferredStyle());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/manual")
+    @Operation(summary = "수동 매칭 요청", description = "특정 상대방을 선택하여 매칭을 요청합니다.")
+    public ResponseEntity<MatchingResponse> requestManualMatch(
+            @Valid @RequestBody ManualMatchRequest request) {
+
+        MatchingResponse response = matchingService.manualMatch(
+                request.getInitiatorId(), request.getInitiatorType(),
+                request.getRecipientId(), request.getRequestedFields());
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{matchingId}/accept")
+    @Operation(summary = "매칭 수락", description = "요청된 매칭을 수락합니다.")
+    public ResponseEntity<MatchingResponse> acceptMatching(
+            @PathVariable Long matchingId,
+            @Valid @RequestBody MatchingActionRequest request) {
+
+        MatchingResponse response = matchingService.acceptMatching(
+                matchingId, request.getProfileId(), request.getProfileType());
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{matchingId}/reject")
+    @Operation(summary = "매칭 거절", description = "요청된 매칭을 거절합니다.")
+    public ResponseEntity<MatchingResponse> rejectMatching(
+            @PathVariable Long matchingId,
+            @Valid @RequestBody MatchingRejectRequest request) {
+
+        MatchingResponse response = matchingService.rejectMatching(
+                matchingId, request.getProfileId(), request.getProfileType(), request.getReason());
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{matchingId}/cancel")
+    @Operation(summary = "매칭 취소", description = "요청한 매칭을 취소합니다.")
+    public ResponseEntity<MatchingResponse> cancelMatching(
+            @PathVariable Long matchingId,
+            @Valid @RequestBody MatchingActionRequest request) {
+
+        MatchingResponse response = matchingService.cancelMatching(
+                matchingId, request.getProfileId(), request.getProfileType());
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{matchingId}/complete")
+    @Operation(summary = "매칭 완료", description = "진행 중인 매칭을 완료합니다.")
+    public ResponseEntity<MatchingResponse> completeMatching(
+            @PathVariable Long matchingId,
+            @Valid @RequestBody MatchingActionRequest request) {
+
+        MatchingResponse response = matchingService.completeMatching(
+                matchingId, request.getProfileId(), request.getProfileType());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/controller/WaitingController.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/controller/WaitingController.java
@@ -1,0 +1,76 @@
+package com.mindmate.mindmate_server.matching.controller;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import com.mindmate.mindmate_server.matching.dto.ListenerStatus;
+import com.mindmate.mindmate_server.matching.dto.ListenerStatusUpdateRequest;
+import com.mindmate.mindmate_server.matching.dto.SpeakerStatusUpdateRequest;
+import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
+import com.mindmate.mindmate_server.matching.service.WaitingService;
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import com.mindmate.mindmate_server.user.domain.CounselingStyle;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/waiting")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Waiting", description = "대기 상태 관리 관련 API")
+public class WaitingController {
+    private final WaitingService waitingService;
+
+    @PutMapping("/listener/{listenerId}/status")
+    @Operation(summary = "리스너 상태 업데이트", description = "리스너의 현재 상태를 업데이트합니다.")
+    public ResponseEntity<Void> updateListenerStatus(
+            @PathVariable Long listenerId,
+            @Valid @RequestBody ListenerStatusUpdateRequest request) {
+
+        waitingService.updateListenerStatus(listenerId, request.getStatus());
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/speaker/{speakerId}/status")
+    @Operation(summary = "스피커 대기 상태 업데이트", description = "스피커가 매칭 대기 상태로 전환하거나 취소합니다.")
+    public ResponseEntity<Void> updateSpeakerStatus(
+            @PathVariable Long speakerId,
+            @Valid @RequestBody SpeakerStatusUpdateRequest request) {
+
+        waitingService.updateSpeakerStatus(
+                speakerId,
+                request.isAvailable(),
+                request.getPreferredFields(),
+                request.getPreferredStyle());
+        return ResponseEntity.ok().build();
+    }
+    @GetMapping("/listeners")
+    @Operation(summary = "대기 중인 리스너 목록 조회", description = "상담 가능한 리스너 목록을 조회합니다.")
+    public ResponseEntity<List<WaitingProfile>> getWaitingListeners() {
+        List<WaitingProfile> listeners = waitingService.getWaitingListeners();
+        return ResponseEntity.ok(listeners);
+    }
+
+    @GetMapping("/speakers")
+    @Operation(summary = "대기 중인 스피커 목록 조회", description = "매칭 대기 중인 스피커 목록을 조회합니다.")
+    public ResponseEntity<List<WaitingProfile>> getWaitingSpeakers() {
+        List<WaitingProfile> speakers = waitingService.getWaitingSpeakers();
+        return ResponseEntity.ok(speakers);
+    }
+
+    @GetMapping("/status/{profileId}")
+    @Operation(summary = "사용자 대기 상태 확인", description = "사용자가 현재 대기 중인지 확인합니다.")
+    public ResponseEntity<Boolean> checkWaitingStatus(
+            @PathVariable Long profileId,
+            @RequestParam InitiatorType userType) {
+
+        boolean isWaiting = waitingService.isUserWaiting(profileId, userType);
+        return ResponseEntity.ok(isWaiting);
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/controller/WaitingController.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/controller/WaitingController.java
@@ -4,7 +4,7 @@ import com.mindmate.mindmate_server.matching.domain.InitiatorType;
 import com.mindmate.mindmate_server.matching.dto.ListenerStatus;
 import com.mindmate.mindmate_server.matching.dto.ListenerStatusUpdateRequest;
 import com.mindmate.mindmate_server.matching.dto.SpeakerStatusUpdateRequest;
-import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
+import com.mindmate.mindmate_server.matching.dto.WaitingProfileResponse;
 import com.mindmate.mindmate_server.matching.service.WaitingService;
 import com.mindmate.mindmate_server.user.domain.CounselingField;
 import com.mindmate.mindmate_server.user.domain.CounselingStyle;
@@ -52,15 +52,15 @@ public class WaitingController {
     }
     @GetMapping("/listeners")
     @Operation(summary = "대기 중인 리스너 목록 조회", description = "상담 가능한 리스너 목록을 조회합니다.")
-    public ResponseEntity<List<WaitingProfile>> getWaitingListeners() {
-        List<WaitingProfile> listeners = waitingService.getWaitingListeners();
+    public ResponseEntity<List<WaitingProfileResponse>> getWaitingListeners() {
+        List<WaitingProfileResponse> listeners = waitingService.getWaitingListeners();
         return ResponseEntity.ok(listeners);
     }
 
     @GetMapping("/speakers")
     @Operation(summary = "대기 중인 스피커 목록 조회", description = "매칭 대기 중인 스피커 목록을 조회합니다.")
-    public ResponseEntity<List<WaitingProfile>> getWaitingSpeakers() {
-        List<WaitingProfile> speakers = waitingService.getWaitingSpeakers();
+    public ResponseEntity<List<WaitingProfileResponse>> getWaitingSpeakers() {
+        List<WaitingProfileResponse> speakers = waitingService.getWaitingSpeakers();
         return ResponseEntity.ok(speakers);
     }
 

--- a/src/main/java/com/mindmate/mindmate_server/matching/domain/InitiatorType.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/domain/InitiatorType.java
@@ -1,0 +1,13 @@
+package com.mindmate.mindmate_server.matching.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum InitiatorType {
+    SPEAKER("상담자 요청"),
+    LISTENER("리스너 요청");
+
+    private final String title;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/domain/Matching.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/domain/Matching.java
@@ -1,13 +1,71 @@
 package com.mindmate.mindmate_server.matching.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import com.mindmate.mindmate_server.user.domain.ListenerProfile;
+import com.mindmate.mindmate_server.user.domain.SpeakerProfile;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
-public class Matching {
+@Table(name = "matchings")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Matching extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "speaker_profile_id")
+    private SpeakerProfile speakerProfile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "listener_profile_id")
+    private ListenerProfile listenerProfile;
+
+    @Enumerated(EnumType.STRING)
+    private MatchingType type;
+
+    @Enumerated(EnumType.STRING)
+    private MatchingStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private InitiatorType initiator; // 요청 주체
+
+    private String rejectionReason;
+
+    @Column(name = "matched_at")
+    private LocalDateTime matchedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "chat_room_id")
+    private String chatRoomId;
+
+    @ElementCollection
+    @CollectionTable(name = "matching_requested_fields",
+            joinColumns = @JoinColumn(name = "matching_id"))
+    @Enumerated(EnumType.STRING)
+    private Set<CounselingField> requestedFields = new HashSet<>();
+
+    @Builder
+    public Matching(SpeakerProfile speakerProfile, ListenerProfile listenerProfile,
+                    MatchingType type, Set<CounselingField> requestedFields,
+                    InitiatorType initiator) {
+        this.speakerProfile = speakerProfile;
+        this.listenerProfile = listenerProfile;
+        this.type = type;
+        this.status = MatchingStatus.REQUESTED;
+        this.requestedFields = requestedFields != null ? requestedFields : new HashSet<>();
+        this.initiator = initiator;
+    }
 }

--- a/src/main/java/com/mindmate/mindmate_server/matching/domain/Matching.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/domain/Matching.java
@@ -68,4 +68,23 @@ public class Matching extends BaseTimeEntity {
         this.requestedFields = requestedFields != null ? requestedFields : new HashSet<>();
         this.initiator = initiator;
     }
+
+    public void accept() {
+        this.status = MatchingStatus.ACCEPTED;
+        this.matchedAt = LocalDateTime.now();
+    }
+
+    public void reject(String reason) {
+        this.status = MatchingStatus.REJECTED;
+        this.rejectionReason = reason;
+    }
+
+    public void complete() {
+        this.status = MatchingStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void cancel() {
+        this.status = MatchingStatus.CANCELED;
+    }
 }

--- a/src/main/java/com/mindmate/mindmate_server/matching/domain/Matching.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/domain/Matching.java
@@ -87,4 +87,8 @@ public class Matching extends BaseTimeEntity {
     public void cancel() {
         this.status = MatchingStatus.CANCELED;
     }
+
+    public void setChatRoomId(String chatRoomId) {
+        this.chatRoomId = chatRoomId;
+    }
 }

--- a/src/main/java/com/mindmate/mindmate_server/matching/domain/MatchingStatus.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/domain/MatchingStatus.java
@@ -1,0 +1,17 @@
+package com.mindmate.mindmate_server.matching.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MatchingStatus {
+    REQUESTED("요청됨"),
+    ACCEPTED("수락됨"),
+    REJECTED("거절됨"),
+    COMPLETED("완료됨"),
+    CANCELED("취소됨");
+
+    private final String title;
+}
+

--- a/src/main/java/com/mindmate/mindmate_server/matching/domain/MatchingType.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/domain/MatchingType.java
@@ -1,0 +1,14 @@
+package com.mindmate.mindmate_server.matching.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MatchingType {
+    AUTO_RANDOM("랜덤 매칭"),
+    AUTO_FORMAT("맞춤 매칭"),
+    MANUAL("직접 선택"); // 수동 매칭
+
+    private final String title;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/domain/WaitingQueue.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/domain/WaitingQueue.java
@@ -1,0 +1,97 @@
+package com.mindmate.mindmate_server.matching.domain;
+
+import com.mindmate.mindmate_server.global.entity.BaseTimeEntity;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.global.exception.MatchingErrorCode;
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import com.mindmate.mindmate_server.user.domain.CounselingStyle;
+import com.mindmate.mindmate_server.user.domain.ListenerProfile;
+import com.mindmate.mindmate_server.user.domain.SpeakerProfile;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "waiting_queue")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WaitingQueue extends BaseTimeEntity { // 대기상태 관리
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "speaker_profile_id")
+    private SpeakerProfile speakerProfile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "listener_profile_id")
+    private ListenerProfile listenerProfile;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InitiatorType waitingType;
+
+    @ElementCollection
+    @CollectionTable(name = "waiting_queue_preferred_fields",
+            joinColumns = @JoinColumn(name = "waiting_queue_id"))
+    @Enumerated(EnumType.STRING)
+    private Set<CounselingField> preferredFields = new HashSet<>();
+
+    @Enumerated(EnumType.STRING)
+    private CounselingStyle preferredStyle;
+
+    private boolean active = true; // 대기중일 때 true, 완료 or 취소일 때 false
+
+    @Builder
+    public WaitingQueue(SpeakerProfile speakerProfile, ListenerProfile listenerProfile,
+                        InitiatorType waitingType, Set<CounselingField> preferredFields,
+                        CounselingStyle preferredStyle) {
+        if ((speakerProfile != null && listenerProfile != null) ||
+                (speakerProfile == null && listenerProfile == null)) {
+            throw new CustomException(MatchingErrorCode.INVALID_WAITING_QUEUE);
+        } // 하나만 들어와야함
+
+        if (speakerProfile != null && waitingType != InitiatorType.SPEAKER) {
+            throw new CustomException(MatchingErrorCode.INVALID_WAITING_QUEUE);
+        }
+
+        if (listenerProfile != null && waitingType != InitiatorType.LISTENER) {
+            throw new CustomException(MatchingErrorCode.INVALID_WAITING_QUEUE);
+        }
+
+        this.speakerProfile = speakerProfile;
+        this.listenerProfile = listenerProfile;
+        this.waitingType = waitingType;
+        this.preferredFields = preferredFields != null ? preferredFields : new HashSet<>();
+        this.preferredStyle = preferredStyle;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    } // 비활성화
+
+    public void updatePreferences(Set<CounselingField> preferredFields, CounselingStyle preferredStyle) {
+        if (preferredFields != null) {
+            this.preferredFields.clear();
+            this.preferredFields.addAll(preferredFields);
+        }
+
+        if (preferredStyle != null) {
+            this.preferredStyle = preferredStyle;
+        }
+    }
+
+    public boolean isSpeaker() {
+        return this.waitingType == InitiatorType.SPEAKER;
+    }
+
+    public boolean isListener() {
+        return this.waitingType == InitiatorType.LISTENER;
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/AutoFormatMatchRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/AutoFormatMatchRequest.java
@@ -1,0 +1,22 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import com.mindmate.mindmate_server.user.domain.CounselingStyle;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AutoFormatMatchRequest {
+    private Long profileId;
+    private InitiatorType initiatorType;
+    private Set<CounselingField> requestedFields;
+    private CounselingStyle preferredStyle;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/AutoFormatMatchRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/AutoFormatMatchRequest.java
@@ -3,14 +3,11 @@ package com.mindmate.mindmate_server.matching.dto;
 import com.mindmate.mindmate_server.matching.domain.InitiatorType;
 import com.mindmate.mindmate_server.user.domain.CounselingField;
 import com.mindmate.mindmate_server.user.domain.CounselingStyle;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.Set;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/AutoRandomMatchRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/AutoRandomMatchRequest.java
@@ -1,0 +1,11 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import lombok.Data;
+
+@Data
+public class AutoRandomMatchRequest {
+
+    private Long profileId;
+    private InitiatorType initiatorType;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/AutoRandomMatchRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/AutoRandomMatchRequest.java
@@ -2,8 +2,9 @@ package com.mindmate.mindmate_server.matching.dto;
 
 import com.mindmate.mindmate_server.matching.domain.InitiatorType;
 import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class AutoRandomMatchRequest {
 
     private Long profileId;

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/ListenerProfile.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/ListenerProfile.java
@@ -1,0 +1,23 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ListenerProfile {
+    private Long id;
+    private String nickname;
+    private String profileImage;
+    private String counselingStyle;
+    private Set<String> counselingFields;
+    private Integer counselingCount;
+    private Float averageRating;
+    private ListenerStatus status;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/ListenerProfileMatchingReqeust.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/ListenerProfileMatchingReqeust.java
@@ -1,17 +1,14 @@
 package com.mindmate.mindmate_server.matching.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.Set;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ListenerProfile {
+public class ListenerProfileMatchingReqeust {
     private Long id;
     private String nickname;
     private String profileImage;

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/ListenerStatus.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/ListenerStatus.java
@@ -1,0 +1,15 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ListenerStatus {
+    AVAILABLE("상담 가능"),
+    BUSY("상담 중"),
+    AWAY("자리 비움"),
+    OFFLINE("오프라인");
+
+    private final String title;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/ListenerStatusUpdateRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/ListenerStatusUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ListenerStatusUpdateRequest {
+    @NotNull(message = "상태 값은 필수입니다")
+    private ListenerStatus status;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/ListenerStatusUpdateRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/ListenerStatusUpdateRequest.java
@@ -3,9 +3,10 @@ package com.mindmate.mindmate_server.matching.dto;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ListenerStatusUpdateRequest {

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/ManualMatchRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/ManualMatchRequest.java
@@ -1,0 +1,21 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ManualMatchRequest {
+    private Long initiatorId;
+    private InitiatorType initiatorType;
+    private Long recipientId;
+    private Set<CounselingField> requestedFields;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/ManualMatchRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/ManualMatchRequest.java
@@ -2,14 +2,11 @@ package com.mindmate.mindmate_server.matching.dto;
 
 import com.mindmate.mindmate_server.matching.domain.InitiatorType;
 import com.mindmate.mindmate_server.user.domain.CounselingField;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.Set;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/MatchingActionRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/MatchingActionRequest.java
@@ -1,0 +1,18 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchingActionRequest { // 수락, 취소, 완료
+    @NotNull(message = "프로필 ID는 필수입니다")
+    private Long profileId;
+
+    @NotNull(message = "프로필 타입은 필수입니다")
+    private InitiatorType profileType;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/MatchingActionRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/MatchingActionRequest.java
@@ -4,9 +4,10 @@ import com.mindmate.mindmate_server.matching.domain.InitiatorType;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class MatchingActionRequest { // 수락, 취소, 완료

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/MatchingRejectRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/MatchingRejectRequest.java
@@ -1,0 +1,20 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchingRejectRequest {
+    @NotNull(message = "프로필 ID는 필수입니다")
+    private Long profileId;
+
+    @NotNull(message = "프로필 타입은 필수입니다")
+    private InitiatorType profileType;
+
+    private String reason;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/MatchingRejectRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/MatchingRejectRequest.java
@@ -4,9 +4,10 @@ import com.mindmate.mindmate_server.matching.domain.InitiatorType;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class MatchingRejectRequest {

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/MatchingResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/MatchingResponse.java
@@ -1,0 +1,30 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import com.mindmate.mindmate_server.matching.domain.MatchingStatus;
+import com.mindmate.mindmate_server.matching.domain.MatchingType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchingResponse {
+    private Long id;
+    private Long speakerProfileId;
+    private Long listenerProfileId;
+    // 이름 추가 할지 말지 결정
+    private MatchingStatus status;
+    private MatchingType type;
+    private InitiatorType initiator;
+    private Set<String> requestedFields;
+    private LocalDateTime requestedAt;
+    private LocalDateTime matchedAt;
+    private LocalDateTime completedAt;
+    private String chatRoomId;
+    private String message;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/SpeakerProfile.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/SpeakerProfile.java
@@ -1,0 +1,28 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SpeakerProfile {
+    private Long id;
+    private String nickname;
+    private String profileImage;
+    private String preferredCounselingStyle;
+    private Integer counselingCount;
+    private Float averageRating;
+    private Set<String> requestedFields;
+    private String preferredStyle;
+    // speaker status를 만들지 고민중
+    private boolean isWaiting;
+    private LocalDateTime waitingSince;
+
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/SpeakerProfileMatchingRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/SpeakerProfileMatchingRequest.java
@@ -1,18 +1,15 @@
 package com.mindmate.mindmate_server.matching.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.Set;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SpeakerProfile {
+public class SpeakerProfileMatchingRequest {
     private Long id;
     private String nickname;
     private String profileImage;

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/SpeakerStatusUpdateRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/SpeakerStatusUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import com.mindmate.mindmate_server.user.domain.CounselingStyle;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SpeakerStatusUpdateRequest {
+    @NotNull(message = "가용성 값은 필수입니다")
+    private boolean available;
+    private Set<CounselingField> preferredFields;
+    private CounselingStyle preferredStyle;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/SpeakerStatusUpdateRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/SpeakerStatusUpdateRequest.java
@@ -5,11 +5,12 @@ import com.mindmate.mindmate_server.user.domain.CounselingStyle;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.Set;
 
-@Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class SpeakerStatusUpdateRequest {

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/WaitingProfile.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/WaitingProfile.java
@@ -1,0 +1,22 @@
+package com.mindmate.mindmate_server.matching.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WaitingProfile {
+    private Long profileId;
+    private String nickname;
+    private String profileImage;
+    private Set<String> requestedFields;
+    private String preferredStyle;
+    private LocalDateTime waitingSince;
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/WaitingProfile.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/WaitingProfile.java
@@ -19,4 +19,5 @@ public class WaitingProfile {
     private Set<String> requestedFields;
     private String preferredStyle;
     private LocalDateTime waitingSince;
+    private String userType;
 }

--- a/src/main/java/com/mindmate/mindmate_server/matching/dto/WaitingProfileResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/dto/WaitingProfileResponse.java
@@ -1,18 +1,15 @@
 package com.mindmate.mindmate_server.matching.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.Set;
 
-@Data
+//@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class WaitingProfile {
+public class WaitingProfileResponse {
     private Long profileId;
     private String nickname;
     private String profileImage;

--- a/src/main/java/com/mindmate/mindmate_server/matching/repository/MatchingRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/repository/MatchingRepository.java
@@ -1,0 +1,9 @@
+package com.mindmate.mindmate_server.matching.repository;
+
+import com.mindmate.mindmate_server.matching.domain.Matching;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MatchingRepository extends JpaRepository<Matching, Long> {
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/repository/WaitingQueueRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/repository/WaitingQueueRepository.java
@@ -1,0 +1,66 @@
+package com.mindmate.mindmate_server.matching.repository;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import com.mindmate.mindmate_server.matching.domain.WaitingQueue;
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import com.mindmate.mindmate_server.user.domain.CounselingStyle;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Repository
+public interface WaitingQueueRepository extends JpaRepository<WaitingQueue, Long> {
+
+    // todo : querydsl 사용
+
+    // 요청자 타입 & 활성 여부
+    List<WaitingQueue> findByWaitingTypeAndActiveOrderByCreatedAtAsc(InitiatorType waitingType, boolean active);
+
+    // 타입, 활성 여부, 스타일
+    List<WaitingQueue> findByWaitingTypeAndActiveAndPreferredStyleOrderByCreatedAtAsc(
+            InitiatorType waitingType, boolean active, CounselingStyle preferredStyle);
+
+    // 특정 유저 활성 여부
+    Optional<WaitingQueue> findBySpeakerProfileIdAndActiveTrue(Long speakerProfileId);
+    Optional<WaitingQueue> findByListenerProfileIdAndActiveTrue(Long listenerProfileId);
+
+    // 특정 상담 분야
+    @Query("SELECT wq FROM WaitingQueue wq WHERE wq.waitingType = 'SPEAKER' AND wq.active = true " +
+            "AND :field MEMBER OF wq.preferredFields ORDER BY wq.createdAt ASC")
+    List<WaitingQueue> findActiveSpeakersByPreferredField(@Param("field") CounselingField field);
+
+    @Query("SELECT wq FROM WaitingQueue wq JOIN wq.listenerProfile lp JOIN lp.counselingFields cf " +
+            "WHERE wq.waitingType = 'LISTENER' AND wq.active = true " +
+            "AND cf.field = :field ORDER BY wq.createdAt ASC")
+    List<WaitingQueue> findActiveListenersByField(@Param("field") CounselingField field);
+
+    // 여러 상담 분야 중 하나
+    @Query("SELECT wq FROM WaitingQueue wq WHERE wq.waitingType = 'SPEAKER' AND wq.active = true " +
+            "AND wq.preferredFields IN :fields ORDER BY wq.createdAt ASC")
+    List<WaitingQueue> findActiveSpeakersByPreferredFields(@Param("fields") Set<CounselingField> fields);
+
+    @Query("SELECT DISTINCT wq FROM WaitingQueue wq JOIN wq.listenerProfile lp JOIN lp.counselingFields cf " +
+            "WHERE wq.waitingType = 'LISTENER' AND wq.active = true " +
+            "AND cf.field IN :fields ORDER BY wq.createdAt ASC")
+    List<WaitingQueue> findActiveListenersByPreferredFields(@Param("fields") Set<CounselingField> fields);
+
+
+    // 상담 분야 + 스타일
+    @Query("SELECT wq FROM WaitingQueue wq WHERE wq.waitingType = 'SPEAKER' AND wq.active = true " +
+            "AND wq.preferredFields IN :fields AND wq.preferredStyle = :style ORDER BY wq.createdAt ASC")
+    List<WaitingQueue> findActiveSpeakersByFieldsAndStyle(
+            @Param("fields") Set<CounselingField> fields,
+            @Param("style") CounselingStyle style);
+
+    @Query("SELECT DISTINCT wq FROM WaitingQueue wq JOIN wq.listenerProfile lp JOIN lp.counselingFields cf " +
+            "WHERE wq.waitingType = 'LISTENER' AND wq.active = true " +
+            "AND cf.field IN :fields AND lp.counselingStyle = :style ORDER BY wq.createdAt ASC")
+    List<WaitingQueue> findActiveListenersByFieldsAndStyle(
+            @Param("fields") Set<CounselingField> fields,
+            @Param("style") CounselingStyle style);
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/repository/WaitingQueueRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/repository/WaitingQueueRepository.java
@@ -40,8 +40,9 @@ public interface WaitingQueueRepository extends JpaRepository<WaitingQueue, Long
     List<WaitingQueue> findActiveListenersByField(@Param("field") CounselingField field);
 
     // 여러 상담 분야 중 하나
-    @Query("SELECT wq FROM WaitingQueue wq WHERE wq.waitingType = 'SPEAKER' AND wq.active = true " +
-            "AND wq.preferredFields IN :fields ORDER BY wq.createdAt ASC")
+    @Query("SELECT DISTINCT wq FROM WaitingQueue wq JOIN wq.preferredFields pf " +
+            "WHERE wq.waitingType = 'SPEAKER' AND wq.active = true " +
+            "AND pf IN :fields ORDER BY wq.createdAt ASC")
     List<WaitingQueue> findActiveSpeakersByPreferredFields(@Param("fields") Set<CounselingField> fields);
 
     @Query("SELECT DISTINCT wq FROM WaitingQueue wq JOIN wq.listenerProfile lp JOIN lp.counselingFields cf " +
@@ -51,8 +52,9 @@ public interface WaitingQueueRepository extends JpaRepository<WaitingQueue, Long
 
 
     // 상담 분야 + 스타일
-    @Query("SELECT wq FROM WaitingQueue wq WHERE wq.waitingType = 'SPEAKER' AND wq.active = true " +
-            "AND wq.preferredFields IN :fields AND wq.preferredStyle = :style ORDER BY wq.createdAt ASC")
+    @Query("SELECT DISTINCT wq FROM WaitingQueue wq JOIN wq.preferredFields pf " +
+            "WHERE wq.waitingType = 'SPEAKER' AND wq.active = true " +
+            "AND pf IN :fields AND wq.preferredStyle = :style ORDER BY wq.createdAt ASC")
     List<WaitingQueue> findActiveSpeakersByFieldsAndStyle(
             @Param("fields") Set<CounselingField> fields,
             @Param("style") CounselingStyle style);

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingEventConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingEventConsumer.java
@@ -1,0 +1,144 @@
+package com.mindmate.mindmate_server.matching.service;
+
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.global.exception.MatchingErrorCode;
+import com.mindmate.mindmate_server.matching.domain.Matching;
+import com.mindmate.mindmate_server.matching.dto.ListenerStatus;
+import com.mindmate.mindmate_server.matching.repository.MatchingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MatchingEventConsumer {
+
+    private final MatchingRepository matchingRepository;
+    private final WaitingService waitingService;
+
+    @KafkaListener(topics = "matching-events", groupId = "mindmate-matching")
+    @Transactional
+    public void consumeMatchingEvent(String message) {
+        log.info("받은 메시지: {}", message);
+
+        try {
+            String[] parts = message.split(":");
+            if (parts.length < 4) {
+                log.error("메시지 형식이 유효하지 않습니다.: {}", message);
+                return;
+            }
+
+            String eventType = parts[0];
+            Long matchingId = Long.parseLong(parts[1]);
+            Long speakerId = Long.parseLong(parts[2]);
+            Long listenerId = Long.parseLong(parts[3]);
+
+            Matching matching = matchingRepository.findById(matchingId)
+                    .orElseThrow(() -> new CustomException(MatchingErrorCode.MATCHING_NOT_FOUND));
+
+            switch (eventType) {
+                case "MATCHING_REQUESTED":
+                    handleMatchingRequested(matching, speakerId, listenerId);
+                    break;
+                case "MATCHING_ACCEPTED":
+                    handleMatchingAccepted(matching, speakerId, listenerId);
+                    break;
+                case "MATCHING_REJECTED":
+                    handleMatchingRejected(matching, speakerId, listenerId);
+                    break;
+                case "MATCHING_CANCELED":
+                    handleMatchingCanceled(matching, speakerId, listenerId);
+                    break;
+                case "MATCHING_COMPLETED":
+                    handleMatchingCompleted(matching, speakerId, listenerId);
+                    break;
+                default:
+                    log.warn("타입을 알 수 없습니다.: {}", eventType);
+            }
+        } catch (Exception e) {
+            log.error("발생한 에러: {}", message, e);
+        }
+    }
+
+    private void handleMatchingRequested(Matching matching, Long speakerId, Long listenerId) {
+        log.info("요청 처리중... {}", matching.getId());
+
+        // 매칭 요청 시 처리할 로직..
+        // 채팅방 준비, 상태 업데이트 등
+        // todo : 알림 발송
+
+        if (matching.getInitiator().toString().equals("SPEAKER")) {
+            // 스피커가 요청 -> 리스너에게 알림
+            log.info("스피커 {} -> 리스너 {}", speakerId, listenerId);
+        } else {
+            // 리스너가 요청 -> 스피커에게 알림
+            log.info("리스너 {} -> 스피커 {}", listenerId, speakerId);
+        }
+    }
+
+    private void handleMatchingAccepted(Matching matching, Long speakerId, Long listenerId) {
+        log.info("요청 수락중... {}", matching.getId());
+
+        waitingService.updateListenerStatus(listenerId, ListenerStatus.BUSY);
+
+        // todo : 채팅방 활성화 로직
+
+        // todo : 수락 알림 추가
+        if (matching.getInitiator().toString().equals("SPEAKER")) {
+            // 스피커가 요청 -> 스피커
+            log.info("스피커 {} -> 리스너 {}", speakerId, listenerId);
+        } else {
+            // 리스너가 요청 -> 리스너
+            log.info("리스너 {} -> 스피커 {}", listenerId, speakerId);
+        }
+    }
+
+    private void handleMatchingRejected(Matching matching, Long speakerId, Long listenerId) {
+        log.info("요청 거절중... {}", matching.getId());
+
+        String reason = matching.getRejectionReason();
+
+
+        // todo : 알림
+        if (matching.getInitiator().toString().equals("SPEAKER")) {
+            log.info("스피커 {} -> 리스너 {} 거절 사유: {}",
+                    speakerId, listenerId, reason);
+        } else {
+            log.info("리스너 {} -> 스피커 {} 거절 사유: {}",
+                    listenerId, speakerId, reason);
+        }
+    }
+
+    private void handleMatchingCanceled(Matching matching, Long speakerId, Long listenerId) {
+        log.info("요청 취소중... {}", matching.getId());
+
+        // 수락된 상태면 status 복원
+        if (matching.getMatchedAt() != null) {
+            waitingService.updateListenerStatus(listenerId, ListenerStatus.AVAILABLE);
+        }
+
+        // todo : 알림 추가
+        if (matching.getInitiator().toString().equals("SPEAKER")) {
+            log.info("스피커 {} -> 리스너 {}",
+                    speakerId, listenerId);
+        } else {
+            log.info("리스너 {} -> 스피커 {}",
+                    listenerId, speakerId);
+        }
+    }
+
+    private void handleMatchingCompleted(Matching matching, Long speakerId, Long listenerId) {
+        log.info("매칭 완료중 {}", matching.getId());
+
+        waitingService.updateListenerStatus(listenerId, ListenerStatus.AVAILABLE);
+
+        // todo : 상담 통계 업데이트
+        log.info("리스너 {} && 스피커 {}",
+                speakerId, listenerId);
+
+        // todo : 후기 작성 알림은 나중에 구현
+    }
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingEventConsumer.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingEventConsumer.java
@@ -19,7 +19,7 @@ public class MatchingEventConsumer {
     private final MatchingRepository matchingRepository;
     private final WaitingService waitingService;
 
-    @KafkaListener(topics = "matching-events", groupId = "mindmate-matching")
+    @KafkaListener(topics = "matching-events", groupId = "mindmate-group")
     @Transactional
     public void consumeMatchingEvent(String message) {
         log.info("받은 메시지: {}", message);

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingService.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingService.java
@@ -2,11 +2,13 @@ package com.mindmate.mindmate_server.matching.service;
 
 import com.mindmate.mindmate_server.matching.domain.InitiatorType;
 import com.mindmate.mindmate_server.matching.dto.MatchingResponse;
+import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
 import com.mindmate.mindmate_server.user.domain.CounselingField;
 import com.mindmate.mindmate_server.user.domain.CounselingStyle;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Set;
 
 @Service
@@ -28,4 +30,8 @@ public interface MatchingService {
     MatchingResponse cancelMatching(Long matchingId, Long profileId, InitiatorType profileType);
 
     MatchingResponse completeMatching(Long matchingId, Long profileId, InitiatorType profileType);
+
+    List<WaitingProfile> getWaitingListenersForMatching();
+
+    List<WaitingProfile> getWaitingSpeakersForMatching();
 }

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingService.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingService.java
@@ -1,0 +1,31 @@
+package com.mindmate.mindmate_server.matching.service;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import com.mindmate.mindmate_server.matching.dto.MatchingResponse;
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import com.mindmate.mindmate_server.user.domain.CounselingStyle;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+public interface MatchingService {
+
+    MatchingResponse autoRandomMatch(Long profileId, InitiatorType initiatorType);
+
+    MatchingResponse autoFormatMatch(Long profileId, InitiatorType initiatorType,
+                                     Set<CounselingField> requestedFields,
+                                     CounselingStyle preferredStyle);
+
+    MatchingResponse manualMatch(Long initiatorId, InitiatorType initiatorType,
+                                 Long recipientId, Set<CounselingField> requestedFields);
+
+    MatchingResponse acceptMatching(Long matchingId, Long profileId, InitiatorType profileType);
+
+    MatchingResponse rejectMatching(Long matchingId, Long profileId, InitiatorType profileType, String reason);
+
+    MatchingResponse cancelMatching(Long matchingId, Long profileId, InitiatorType profileType);
+
+    MatchingResponse completeMatching(Long matchingId, Long profileId, InitiatorType profileType);
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingService.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingService.java
@@ -2,7 +2,7 @@ package com.mindmate.mindmate_server.matching.service;
 
 import com.mindmate.mindmate_server.matching.domain.InitiatorType;
 import com.mindmate.mindmate_server.matching.dto.MatchingResponse;
-import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
+import com.mindmate.mindmate_server.matching.dto.WaitingProfileResponse;
 import com.mindmate.mindmate_server.user.domain.CounselingField;
 import com.mindmate.mindmate_server.user.domain.CounselingStyle;
 import org.springframework.stereotype.Service;
@@ -31,7 +31,7 @@ public interface MatchingService {
 
     MatchingResponse completeMatching(Long matchingId, Long profileId, InitiatorType profileType);
 
-    List<WaitingProfile> getWaitingListenersForMatching();
+    List<WaitingProfileResponse> getWaitingListenersForMatching();
 
-    List<WaitingProfile> getWaitingSpeakersForMatching();
+    List<WaitingProfileResponse> getWaitingSpeakersForMatching();
 }

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
@@ -1,0 +1,495 @@
+package com.mindmate.mindmate_server.matching.service;
+
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.global.exception.MatchingErrorCode;
+import com.mindmate.mindmate_server.global.exception.ProfileErrorCode;
+import com.mindmate.mindmate_server.matching.domain.*;
+import com.mindmate.mindmate_server.matching.dto.ListenerStatus;
+import com.mindmate.mindmate_server.matching.dto.MatchingResponse;
+import com.mindmate.mindmate_server.matching.repository.MatchingRepository;
+import com.mindmate.mindmate_server.user.domain.*;
+import com.mindmate.mindmate_server.user.repository.ListenerRepository;
+import com.mindmate.mindmate_server.user.repository.SpeakerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MatchingServiceImpl implements MatchingService {
+
+    private final MatchingRepository matchingRepository;
+    private final SpeakerRepository speakerRepository;
+    private final ListenerRepository listenerRepository;
+    private final WaitingService waitingService;
+    private final KafkaTemplate<String, String> kafkaTemplate; // string으로 충분할지 고민해보기
+
+    // 랜덤 매칭
+    @Transactional
+    @Override
+    public MatchingResponse autoRandomMatch(Long profileId, InitiatorType initiatorType) {
+        if (initiatorType == InitiatorType.SPEAKER) {
+            return handleSpeakerRandomMatch(profileId);
+        } else {
+            return handleListenerRandomMatch(profileId);
+        }
+    }
+
+    private MatchingResponse handleListenerRandomMatch(Long listenerProfileId) {
+        ListenerProfile listenerProfile = listenerRepository.findById(listenerProfileId)
+                .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        List<WaitingQueue> waitingSpeakers = waitingService.findWaitingUsers(InitiatorType.SPEAKER, null, null);
+
+        if (waitingSpeakers.isEmpty()) { // 없을 때만 추가
+            waitingService.updateListenerStatus(listenerProfileId, ListenerStatus.AVAILABLE);
+
+            return MatchingResponse.builder()
+                    .status(MatchingStatus.REQUESTED)
+                    .message("상담 가능한 스피커가 없습니다. 대기열에 추가됩니다.")
+                    .build();
+        }
+
+        WaitingQueue waitingSpeaker = waitingSpeakers.get(0);
+        SpeakerProfile speakerProfile = waitingSpeaker.getSpeakerProfile();
+
+        Matching matching = Matching.builder()
+                .speakerProfile(speakerProfile)
+                .listenerProfile(listenerProfile)
+                .type(MatchingType.AUTO_RANDOM)
+                .initiator(InitiatorType.LISTENER)
+                .requestedFields(waitingSpeaker.getPreferredFields())
+                .build();
+
+        Matching matched = matchingRepository.save(matching);
+
+        waitingService.updateSpeakerStatus(speakerProfile.getId(), false, null, null);
+
+        publishMatchingEvent("MATCHING_REQUESTED", matched);
+
+        return convertToMatchingResponse(matched);
+    }
+
+    private MatchingResponse handleSpeakerRandomMatch(Long speakerProfileId) {
+        SpeakerProfile speakerProfile = speakerRepository.findById(speakerProfileId)
+                .orElseThrow(()-> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        Set<String> availableListenerIds = waitingService.getAvailableUserIds(InitiatorType.LISTENER);
+        if (availableListenerIds == null || availableListenerIds.isEmpty()) {
+            waitingService.updateSpeakerStatus(speakerProfileId, true, null, null);
+
+            return MatchingResponse.builder()
+                    .status(MatchingStatus.REQUESTED)
+                    .message("상담 가능한 리스너가 없습니다. 대기열에 추가됩니다.")
+                    .build();
+        }
+
+        String randomListenerId = getRandomElement(availableListenerIds);
+        ListenerProfile listenerProfile = listenerRepository.findById(Long.parseLong(randomListenerId))
+                .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        Matching matching = Matching.builder()
+                .speakerProfile(speakerProfile)
+                .listenerProfile(listenerProfile)
+                .type(MatchingType.AUTO_RANDOM)
+                .initiator(InitiatorType.SPEAKER)
+                .build();
+
+        Matching matched = matchingRepository.save(matching);
+
+        publishMatchingEvent("MATCHING_REQUESTED", matched);
+
+        return convertToMatchingResponse(matched);
+    }
+
+    // 형식 매칭
+    @Transactional
+    @Override
+    public MatchingResponse autoFormatMatch(Long profileId, InitiatorType initiatorType,
+                                               Set<CounselingField> requestedFields,
+                                               CounselingStyle preferredStyle) {
+        if (initiatorType == InitiatorType.SPEAKER) {
+            return handleSpeakerFormatMatch(profileId, requestedFields, preferredStyle);
+        } else {
+            return handleListenerFormatMatch(profileId, requestedFields, preferredStyle);
+        }
+    }
+
+    private MatchingResponse handleSpeakerFormatMatch(Long speakerProfileId,
+                                                         Set<CounselingField> requestedFields,
+                                                         CounselingStyle preferredStyle) {
+
+        SpeakerProfile speakerProfile = speakerRepository.findById(speakerProfileId)
+                .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        List<WaitingQueue> availableListenerQueues = waitingService.findWaitingListeners(requestedFields, preferredStyle);
+
+        if (availableListenerQueues.isEmpty()) { // 조건에 안 맞을 시
+            waitingService.addToWaitingQueue(speakerProfileId, InitiatorType.SPEAKER, requestedFields, preferredStyle);
+
+            return MatchingResponse.builder()
+                    .status(MatchingStatus.REQUESTED)
+                    .message("해당 분야의 리스너가 없습니다. 대기열에 추가됩니다.")
+                    .build();
+        }
+
+        ListenerProfile bestListener = availableListenerQueues.get(0).getListenerProfile();
+
+        Matching matching = Matching.builder()
+                .speakerProfile(speakerProfile)
+                .listenerProfile(bestListener)
+                .type(MatchingType.AUTO_FORMAT)
+                .requestedFields(requestedFields)
+                .initiator(InitiatorType.SPEAKER)
+                .build();
+
+        Matching matched = matchingRepository.save(matching);
+
+        waitingService.cancelWaiting(bestListener.getId(), InitiatorType.LISTENER);
+
+        publishMatchingEvent("MATCHING_REQUESTED", matched);
+
+        return convertToMatchingResponse(matched);
+    }
+
+    private MatchingResponse handleListenerFormatMatch(Long listenerProfileId,
+                                                          Set<CounselingField> preferredFields,
+                                                          CounselingStyle preferredStyle) {
+
+        ListenerProfile listenerProfile = listenerRepository.findById(listenerProfileId)
+                .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        List<WaitingQueue> waitingSpeakers = waitingService.findWaitingSpeakers(preferredFields, preferredStyle);
+
+        if (waitingSpeakers.isEmpty()) {
+            waitingService.addToWaitingQueue(listenerProfileId, InitiatorType.LISTENER, preferredFields, preferredStyle);
+
+            return MatchingResponse.builder()
+                    .status(MatchingStatus.REQUESTED)
+                    .message("해당 분야의 스피커가 없습니다. 대기열에 추가됩니다.")
+                    .build();
+        }
+
+        WaitingQueue waitingSpeaker = waitingSpeakers.get(0);
+        SpeakerProfile speakerProfile = waitingSpeaker.getSpeakerProfile();
+
+        Matching matching = Matching.builder()
+                .speakerProfile(speakerProfile)
+                .listenerProfile(listenerProfile)
+                .type(MatchingType.AUTO_FORMAT)
+                .requestedFields(waitingSpeaker.getPreferredFields())
+                .initiator(InitiatorType.LISTENER)
+                .build();
+
+        Matching matched = matchingRepository.save(matching);
+
+        waitingService.cancelWaiting(speakerProfile.getId(), InitiatorType.SPEAKER);
+
+        publishMatchingEvent("MATCHING_REQUESTED", matched);
+
+        return convertToMatchingResponse(matched);
+    }
+
+    // 수동 매칭 - 직접 선택
+    @Transactional
+    @Override
+    public MatchingResponse manualMatch(Long initiatorId, InitiatorType initiatorType,
+                                           Long recipientId, Set<CounselingField> requestedFields) {
+        if (initiatorType == InitiatorType.SPEAKER) {
+            return manualMatchBySpeaker(initiatorId, recipientId, requestedFields);
+        } else {
+            return manualMatchByListener(initiatorId, recipientId);
+        }
+    }
+
+    private MatchingResponse manualMatchBySpeaker(Long speakerProfileId, Long listenerProfileId,
+                                                     Set<CounselingField> requestedFields) {
+
+        SpeakerProfile speakerProfile = speakerRepository.findById(speakerProfileId)
+                .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        ListenerProfile listenerProfile = listenerRepository.findById(listenerProfileId)
+                .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        boolean isListenerAvailable = waitingService.isUserWaiting(listenerProfileId, InitiatorType.LISTENER);
+        if (!isListenerAvailable) {
+            throw new CustomException(MatchingErrorCode.USER_NOT_AVAILABLE);
+        }
+
+        Matching matching = Matching.builder()
+                .speakerProfile(speakerProfile)
+                .listenerProfile(listenerProfile)
+                .type(MatchingType.MANUAL)
+                .requestedFields(requestedFields)
+                .initiator(InitiatorType.SPEAKER)
+                .build();
+
+        Matching savedMatching = matchingRepository.save(matching);
+
+        publishMatchingEvent("MATCHING_REQUESTED", savedMatching);
+
+        return convertToMatchingResponse(savedMatching);
+    }
+
+    private MatchingResponse manualMatchByListener(Long listenerProfileId, Long speakerProfileId) {
+
+        ListenerProfile listenerProfile = listenerRepository.findById(listenerProfileId)
+                .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        SpeakerProfile speakerProfile = speakerRepository.findById(speakerProfileId)
+                .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        boolean isSpeakerWaiting = waitingService.isUserWaiting(speakerProfileId, InitiatorType.SPEAKER);
+
+        if (!isSpeakerWaiting) {
+            throw new CustomException(MatchingErrorCode.USER_NOT_AVAILABLE);
+        }
+
+        Matching matching = Matching.builder()
+                .speakerProfile(speakerProfile)
+                .listenerProfile(listenerProfile)
+                .type(MatchingType.MANUAL)
+                .requestedFields(null) // 대기 큐에서 선호 필드 정보를 가져올까..?
+                .initiator(InitiatorType.LISTENER)
+                .build();
+
+        Matching savedMatching = matchingRepository.save(matching);
+
+        waitingService.cancelWaiting(speakerProfile.getId(), InitiatorType.SPEAKER);
+
+        publishMatchingEvent("MATCHING_REQUESTED", savedMatching);
+
+        return convertToMatchingResponse(savedMatching);
+    }
+
+    // 수락
+    @Transactional
+    @Override
+    public MatchingResponse acceptMatching(Long matchingId, Long profileId, InitiatorType profileType) {
+        Matching matching = matchingRepository.findById(matchingId)
+                .orElseThrow(() -> new CustomException(MatchingErrorCode.MATCHING_NOT_FOUND));
+
+        if (matching.getStatus() != MatchingStatus.REQUESTED) {
+            throw new CustomException(MatchingErrorCode.INVALID_MATCHING_STATUS);
+        }
+
+        //권한 확인
+        validateRecipientAuthorization(matching, profileId, profileType);
+
+//        matching.accept();
+
+        // 채팅방 아이디... 생성??? 연결...
+//        matching.setChatRoomId(chatRoomId);
+
+        ListenerProfile listener = matching.getListenerProfile();
+        waitingService.updateListenerStatus(listener.getId(), ListenerStatus.BUSY);
+
+        publishMatchingEvent("MATCHING_ACCEPTED", matching);
+
+        return convertToMatchingResponse(matching);
+    }
+
+    // 거절
+    @Transactional
+    @Override
+    public MatchingResponse rejectMatching(Long matchingId, Long profileId, InitiatorType profileType, String reason) {
+
+        Matching matching = matchingRepository.findById(matchingId)
+                .orElseThrow(() -> new CustomException(MatchingErrorCode.MATCHING_NOT_FOUND));
+
+        if (matching.getStatus() != MatchingStatus.REQUESTED) {
+            throw new CustomException(MatchingErrorCode.INVALID_MATCHING_STATUS);
+        }
+
+        // 권한 확인
+        validateRecipientAuthorization(matching, profileId, profileType);
+
+        // 제한 확인
+        User user;
+        if (profileType == InitiatorType.LISTENER) {
+            user = matching.getListenerProfile().getUser();
+        } else {
+            user = matching.getSpeakerProfile().getUser();
+        }
+
+        if (!user.addRejectionCount()) {
+            throw new CustomException(MatchingErrorCode.LIMIT_EXCEED);
+        }
+
+//        matching.reject(reason);
+
+        publishMatchingEvent("MATCHING_REJECTED", matching);
+
+        return convertToMatchingResponse(matching);
+    }
+
+    @Transactional
+    @Override
+    public MatchingResponse cancelMatching(Long matchingId, Long profileId, InitiatorType profileType) {
+        Matching matching = matchingRepository.findById(matchingId)
+                .orElseThrow(() -> new CustomException(MatchingErrorCode.MATCHING_NOT_FOUND));
+
+        if (matching.getStatus() != MatchingStatus.REQUESTED && matching.getStatus() != MatchingStatus.ACCEPTED) {
+            throw new CustomException(MatchingErrorCode.INVALID_MATCHING_STATUS);
+        }
+
+        validateInitiatorAuthorization(matching, profileId, profileType);
+
+        // 제한 확인
+        User user;
+        if (profileType == InitiatorType.LISTENER) {
+            user = matching.getListenerProfile().getUser();
+        } else {
+            user = matching.getSpeakerProfile().getUser();
+        }
+
+        if (!user.addCancelCount()) {
+            throw new CustomException(MatchingErrorCode.LIMIT_EXCEED);
+        }
+
+//        matching.cancel();
+
+        // 수락되었을경우
+        if (matching.getStatus() == MatchingStatus.ACCEPTED) {
+            waitingService.updateListenerStatus(matching.getListenerProfile().getId(), ListenerStatus.AVAILABLE);
+        }
+
+        publishMatchingEvent("MATCHING_CANCELED", matching);
+
+        return convertToMatchingResponse(matching);
+    }
+
+    // 매칭 성사됨
+    @Transactional
+    @Override
+    public MatchingResponse completeMatching(Long matchingId, Long profileId, InitiatorType profileType) {
+        Matching matching = matchingRepository.findById(matchingId)
+                .orElseThrow(() -> new CustomException(MatchingErrorCode.MATCHING_NOT_FOUND));
+
+        if (matching.getStatus() != MatchingStatus.ACCEPTED) {
+            throw new CustomException(MatchingErrorCode.INVALID_MATCHING_STATUS);
+        }
+
+        // 권한 - 리스너 스피커 상관 ㄴ
+        boolean isAuthorized = (profileType == InitiatorType.SPEAKER && matching.getSpeakerProfile().getId().equals(profileId)) ||
+                (profileType == InitiatorType.LISTENER && matching.getListenerProfile().getId().equals(profileId));
+
+        if (!isAuthorized) {
+            throw new CustomException(MatchingErrorCode.USER_NOT_AUTHORIZED);
+        }
+
+//        matching.complete();
+
+        ListenerProfile listener = matching.getListenerProfile();
+        SpeakerProfile speaker = matching.getSpeakerProfile();
+
+        listener.incrementCounselingCount();
+        speaker.incrementCounselingCount();
+
+        waitingService.updateListenerStatus(listener.getId(), ListenerStatus.AVAILABLE);
+
+        publishMatchingEvent("MATCHING_COMPLETED", matching);
+
+        return convertToMatchingResponse(matching);
+    }
+
+    // 매칭 이력 조회? 필요하나? 프로필에 보여줄건가
+    // 대기중인 사용자 보여줘?
+    // 진행중인 매칭 조회?
+
+    private String getRandomElement(Set<String> set) {
+        if (set == null || set.isEmpty()) {
+            return null;
+        }
+
+        int randomIndex = (int) (Math.random() * set.size());
+        int i = 0;
+        for (String element : set) {
+            if (i == randomIndex) {
+                return element;
+            }
+            i++;
+        }
+        return null;
+    }
+
+    // 요청 받은 사람 권한
+    private void validateRecipientAuthorization(Matching matching, Long profileId, InitiatorType profileType) {
+        boolean isAuthorized = false;
+
+        if (matching.getInitiator() == InitiatorType.SPEAKER &&
+                profileType == InitiatorType.LISTENER &&
+                matching.getListenerProfile().getId().equals(profileId)) {
+            isAuthorized = true;
+        }
+
+        if (matching.getInitiator() == InitiatorType.LISTENER &&
+                profileType == InitiatorType.SPEAKER &&
+                matching.getSpeakerProfile().getId().equals(profileId)) {
+            isAuthorized = true;
+        }
+
+        if (!isAuthorized) {
+            throw new CustomException(MatchingErrorCode.USER_NOT_AUTHORIZED);
+        }
+    }
+
+    // 요청 보낸 사람 - 당사자만 취소 가능
+    private void validateInitiatorAuthorization(Matching matching, Long profileId, InitiatorType profileType) {
+        boolean isAuthorized = false;
+
+        if (matching.getInitiator() == InitiatorType.SPEAKER &&
+                profileType == InitiatorType.SPEAKER &&
+                matching.getSpeakerProfile().getId().equals(profileId)) {
+            isAuthorized = true;
+        }
+
+        if (matching.getInitiator() == InitiatorType.LISTENER &&
+                profileType == InitiatorType.LISTENER &&
+                matching.getListenerProfile().getId().equals(profileId)) {
+            isAuthorized = true;
+        }
+
+        if (!isAuthorized) {
+            throw new CustomException(MatchingErrorCode.USER_NOT_AUTHORIZED);
+        }
+    }
+
+    private MatchingResponse convertToMatchingResponse(Matching matching) {
+        return MatchingResponse.builder()
+                .id(matching.getId())
+                .speakerProfileId(matching.getSpeakerProfile().getId())
+                .listenerProfileId(matching.getListenerProfile().getId())
+                .status(matching.getStatus())
+                .type(matching.getType())
+                .initiator(matching.getInitiator())
+                .requestedFields(matching.getRequestedFields().stream()
+                        .map(CounselingField::getTitle)
+                        .collect(Collectors.toSet()))
+                .requestedAt(matching.getCreatedAt())
+                .matchedAt(matching.getMatchedAt())
+                .completedAt(matching.getCompletedAt())
+                .chatRoomId(matching.getChatRoomId())
+                .build();
+    }
+
+    private void publishMatchingEvent(String eventType, Matching matching) {
+        String message = String.format("%s:%d:%d:%d",
+                eventType,
+                matching.getId(),
+                matching.getSpeakerProfile().getId(),
+                matching.getListenerProfile().getId()
+        );
+
+        kafkaTemplate.send("matching-events", message);
+        log.info("Published matching event: {}", message);
+    }
+
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
@@ -6,6 +6,7 @@ import com.mindmate.mindmate_server.global.exception.ProfileErrorCode;
 import com.mindmate.mindmate_server.matching.domain.*;
 import com.mindmate.mindmate_server.matching.dto.ListenerStatus;
 import com.mindmate.mindmate_server.matching.dto.MatchingResponse;
+import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
 import com.mindmate.mindmate_server.matching.repository.MatchingRepository;
 import com.mindmate.mindmate_server.user.domain.*;
 import com.mindmate.mindmate_server.user.repository.ListenerRepository;
@@ -490,6 +491,14 @@ public class MatchingServiceImpl implements MatchingService {
 
         kafkaTemplate.send("matching-events", message);
         log.info("Published matching event: {}", message);
+    }
+
+    public List<WaitingProfile> getWaitingListenersForMatching() {
+        return waitingService.getWaitingListeners();
+    }
+
+    public List<WaitingProfile> getWaitingSpeakersForMatching() {
+        return waitingService.getWaitingSpeakers();
     }
 
 }

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
@@ -6,7 +6,7 @@ import com.mindmate.mindmate_server.global.exception.ProfileErrorCode;
 import com.mindmate.mindmate_server.matching.domain.*;
 import com.mindmate.mindmate_server.matching.dto.ListenerStatus;
 import com.mindmate.mindmate_server.matching.dto.MatchingResponse;
-import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
+import com.mindmate.mindmate_server.matching.dto.WaitingProfileResponse;
 import com.mindmate.mindmate_server.matching.repository.MatchingRepository;
 import com.mindmate.mindmate_server.user.domain.*;
 import com.mindmate.mindmate_server.user.repository.ListenerRepository;
@@ -494,12 +494,12 @@ public class MatchingServiceImpl implements MatchingService {
     }
 
     @Override
-    public List<WaitingProfile> getWaitingListenersForMatching() {
+    public List<WaitingProfileResponse> getWaitingListenersForMatching() {
         return waitingService.getWaitingListeners();
     }
 
     @Override
-    public List<WaitingProfile> getWaitingSpeakersForMatching() {
+    public List<WaitingProfileResponse> getWaitingSpeakersForMatching() {
         return waitingService.getWaitingSpeakers();
     }
 

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
@@ -279,7 +279,7 @@ public class MatchingServiceImpl implements MatchingService {
 
         if (matching.getStatus() != MatchingStatus.REQUESTED) {
             throw new CustomException(MatchingErrorCode.INVALID_MATCHING_STATUS);
-        }
+        } // 엔티티 안에 넣을까..?
 
         //권한 확인
         validateRecipientAuthorization(matching, profileId, profileType);

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
@@ -493,10 +493,12 @@ public class MatchingServiceImpl implements MatchingService {
         log.info("Published matching event: {}", message);
     }
 
+    @Override
     public List<WaitingProfile> getWaitingListenersForMatching() {
         return waitingService.getWaitingListeners();
     }
 
+    @Override
     public List<WaitingProfile> getWaitingSpeakersForMatching() {
         return waitingService.getWaitingSpeakers();
     }

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/MatchingServiceImpl.java
@@ -283,7 +283,7 @@ public class MatchingServiceImpl implements MatchingService {
         //권한 확인
         validateRecipientAuthorization(matching, profileId, profileType);
 
-//        matching.accept();
+        matching.accept();
 
         // 채팅방 아이디... 생성??? 연결...
 //        matching.setChatRoomId(chatRoomId);
@@ -323,7 +323,7 @@ public class MatchingServiceImpl implements MatchingService {
             throw new CustomException(MatchingErrorCode.LIMIT_EXCEED);
         }
 
-//        matching.reject(reason);
+        matching.reject(reason);
 
         publishMatchingEvent("MATCHING_REJECTED", matching);
 
@@ -354,7 +354,7 @@ public class MatchingServiceImpl implements MatchingService {
             throw new CustomException(MatchingErrorCode.LIMIT_EXCEED);
         }
 
-//        matching.cancel();
+        matching.cancel();
 
         // 수락되었을경우
         if (matching.getStatus() == MatchingStatus.ACCEPTED) {
@@ -385,7 +385,7 @@ public class MatchingServiceImpl implements MatchingService {
             throw new CustomException(MatchingErrorCode.USER_NOT_AUTHORIZED);
         }
 
-//        matching.complete();
+        matching.complete();
 
         ListenerProfile listener = matching.getListenerProfile();
         SpeakerProfile speaker = matching.getSpeakerProfile();

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingService.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingService.java
@@ -3,7 +3,7 @@ package com.mindmate.mindmate_server.matching.service;
 import com.mindmate.mindmate_server.matching.domain.InitiatorType;
 import com.mindmate.mindmate_server.matching.domain.WaitingQueue;
 import com.mindmate.mindmate_server.matching.dto.ListenerStatus;
-import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
+import com.mindmate.mindmate_server.matching.dto.WaitingProfileResponse;
 import com.mindmate.mindmate_server.user.domain.CounselingField;
 import com.mindmate.mindmate_server.user.domain.CounselingStyle;
 import org.springframework.stereotype.Service;
@@ -18,11 +18,11 @@ public interface WaitingService {
 
     void cancelWaiting(Long profileId, InitiatorType userType);
 
-    List<WaitingProfile> getWaitingUsers(InitiatorType userType);
+    List<WaitingProfileResponse> getWaitingUsers(InitiatorType userType);
 
-    List<WaitingProfile> getWaitingListeners();
+    List<WaitingProfileResponse> getWaitingListeners();
 
-    List<WaitingProfile> getWaitingSpeakers();
+    List<WaitingProfileResponse> getWaitingSpeakers();
 
     void updateListenerStatus(Long listenerId, ListenerStatus status);
 

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingService.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingService.java
@@ -7,7 +7,6 @@ import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
 import com.mindmate.mindmate_server.user.domain.CounselingField;
 import com.mindmate.mindmate_server.user.domain.CounselingStyle;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingService.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingService.java
@@ -1,0 +1,40 @@
+package com.mindmate.mindmate_server.matching.service;
+
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import com.mindmate.mindmate_server.matching.domain.WaitingQueue;
+import com.mindmate.mindmate_server.matching.dto.ListenerStatus;
+import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import com.mindmate.mindmate_server.user.domain.CounselingStyle;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+
+@Service
+public interface WaitingService {
+
+    void addToWaitingQueue(Long profileId, InitiatorType userType, Set<CounselingField> preferredFields, CounselingStyle preferredStyle);
+
+    void cancelWaiting(Long profileId, InitiatorType userType);
+
+    List<WaitingProfile> getWaitingUsers(InitiatorType userType);
+
+    void updateListenerStatus(Long listenerId, ListenerStatus status);
+
+    void updateSpeakerStatus(Long speakerId, boolean isAvailable, Set<CounselingField> preferredFields, CounselingStyle preferredStyle);
+
+    List<WaitingQueue> findWaitingUsers(InitiatorType userType,
+                                        Set<CounselingField> preferredFields,
+                                        CounselingStyle preferredStyle);
+
+    List<WaitingQueue> findWaitingSpeakers(Set<CounselingField> preferredFields, CounselingStyle preferredStyle);
+
+    List<WaitingQueue> findWaitingListeners(Set<CounselingField> preferredFields, CounselingStyle preferredStyle);
+
+    boolean isUserWaiting(Long profileId, InitiatorType userType);
+
+    Set<String> getAvailableUserIds(InitiatorType userType);
+
+    String getUserStatus(Long profileId, InitiatorType userType);
+}

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingService.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingService.java
@@ -7,6 +7,7 @@ import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
 import com.mindmate.mindmate_server.user.domain.CounselingField;
 import com.mindmate.mindmate_server.user.domain.CounselingStyle;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
@@ -20,13 +21,15 @@ public interface WaitingService {
 
     List<WaitingProfile> getWaitingUsers(InitiatorType userType);
 
+    List<WaitingProfile> getWaitingListeners();
+
+    List<WaitingProfile> getWaitingSpeakers();
+
     void updateListenerStatus(Long listenerId, ListenerStatus status);
 
     void updateSpeakerStatus(Long speakerId, boolean isAvailable, Set<CounselingField> preferredFields, CounselingStyle preferredStyle);
 
-    List<WaitingQueue> findWaitingUsers(InitiatorType userType,
-                                        Set<CounselingField> preferredFields,
-                                        CounselingStyle preferredStyle);
+    List<WaitingQueue> findWaitingUsers(InitiatorType userType, Set<CounselingField> preferredFields, CounselingStyle preferredStyle);
 
     List<WaitingQueue> findWaitingSpeakers(Set<CounselingField> preferredFields, CounselingStyle preferredStyle);
 

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingServiceImpl.java
@@ -5,7 +5,7 @@ import com.mindmate.mindmate_server.global.exception.ProfileErrorCode;
 import com.mindmate.mindmate_server.matching.domain.InitiatorType;
 import com.mindmate.mindmate_server.matching.domain.WaitingQueue;
 import com.mindmate.mindmate_server.matching.dto.ListenerStatus;
-import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
+import com.mindmate.mindmate_server.matching.dto.WaitingProfileResponse;
 import com.mindmate.mindmate_server.matching.repository.WaitingQueueRepository;
 import com.mindmate.mindmate_server.user.domain.CounselingField;
 import com.mindmate.mindmate_server.user.domain.CounselingStyle;
@@ -108,7 +108,7 @@ public class WaitingServiceImpl implements WaitingService { // 대기상태 관�
     // 대기중인 유저
     @Transactional(readOnly = true)
     @Override
-    public List<WaitingProfile> getWaitingUsers(InitiatorType userType) {
+    public List<WaitingProfileResponse> getWaitingUsers(InitiatorType userType) {
         if (userType == InitiatorType.LISTENER) {
             return getWaitingListeners();
         } else {
@@ -118,7 +118,7 @@ public class WaitingServiceImpl implements WaitingService { // 대기상태 관�
 
     @Transactional(readOnly = true)
     @Override
-    public List<WaitingProfile> getWaitingListeners() {
+    public List<WaitingProfileResponse> getWaitingListeners() {
         List<WaitingQueue> waitingListeners = waitingQueueRepository.findByWaitingTypeAndActiveOrderByCreatedAtAsc(
                 InitiatorType.LISTENER, true);
 
@@ -126,7 +126,7 @@ public class WaitingServiceImpl implements WaitingService { // 대기상태 관�
                 .map(wq -> {
                     ListenerProfile listener = wq.getListenerProfile();
 
-                    return WaitingProfile.builder()
+                    return WaitingProfileResponse.builder()
                             .profileId(listener.getId())
                             .nickname(listener.getNickname())
                             .profileImage(listener.getProfileImage())
@@ -143,7 +143,7 @@ public class WaitingServiceImpl implements WaitingService { // 대기상태 관�
 
     @Transactional(readOnly = true)
     @Override
-    public List<WaitingProfile> getWaitingSpeakers() {
+    public List<WaitingProfileResponse> getWaitingSpeakers() {
         List<WaitingQueue> waitingSpeakers = waitingQueueRepository.findByWaitingTypeAndActiveOrderByCreatedAtAsc(
                 InitiatorType.SPEAKER, true);
 
@@ -151,7 +151,7 @@ public class WaitingServiceImpl implements WaitingService { // 대기상태 관�
                 .map(wq -> {
                     SpeakerProfile speaker = wq.getSpeakerProfile();
 
-                    return WaitingProfile.builder()
+                    return WaitingProfileResponse.builder()
                             .profileId(speaker.getId())
                             .nickname(speaker.getNickname())
                             .profileImage(speaker.getProfileImage())

--- a/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/matching/service/WaitingServiceImpl.java
@@ -1,0 +1,262 @@
+package com.mindmate.mindmate_server.matching.service;
+
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.global.exception.ProfileErrorCode;
+import com.mindmate.mindmate_server.matching.domain.InitiatorType;
+import com.mindmate.mindmate_server.matching.domain.WaitingQueue;
+import com.mindmate.mindmate_server.matching.dto.ListenerStatus;
+import com.mindmate.mindmate_server.matching.dto.WaitingProfile;
+import com.mindmate.mindmate_server.matching.repository.WaitingQueueRepository;
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import com.mindmate.mindmate_server.user.domain.CounselingStyle;
+import com.mindmate.mindmate_server.user.domain.ListenerProfile;
+import com.mindmate.mindmate_server.user.domain.SpeakerProfile;
+import com.mindmate.mindmate_server.user.repository.ListenerRepository;
+import com.mindmate.mindmate_server.user.repository.SpeakerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WaitingServiceImpl implements WaitingService { // 대기상태 관리
+
+    private final WaitingQueueRepository waitingQueueRepository;
+    private final ListenerRepository listenerProfileRepository;
+    private final SpeakerRepository speakerProfileRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String USERS_AVAILABLE = "users:available:";
+    private static final String LISTENERS_AVAILABLE = USERS_AVAILABLE + "listeners";
+    private static final String SPEAKERS_AVAILABLE = USERS_AVAILABLE + "speakers";
+    private static final String USER_STATUS_PREFIX = "user:status:";
+
+    @Transactional
+    @Override
+    public void addToWaitingQueue(Long profileId, InitiatorType userType,
+                                  Set<CounselingField> preferredFields, CounselingStyle preferredStyle) {
+
+        Optional<WaitingQueue> existingQueue;
+        if (userType == InitiatorType.SPEAKER) {
+            existingQueue = waitingQueueRepository.findBySpeakerProfileIdAndActiveTrue(profileId);
+        } else {
+            existingQueue = waitingQueueRepository.findByListenerProfileIdAndActiveTrue(profileId);
+        }
+
+        if (existingQueue.isPresent()) { // 이미 대기중일 경우
+            WaitingQueue queue = existingQueue.get();
+            queue.updatePreferences(preferredFields, preferredStyle);
+            waitingQueueRepository.save(queue);
+            return;
+        }
+
+        // 아닐 시 대기
+        WaitingQueue waitingQueue;
+        if (userType == InitiatorType.SPEAKER) {
+            SpeakerProfile speakerProfile = speakerProfileRepository.findById(profileId)
+                    .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+            waitingQueue = WaitingQueue.builder()
+                    .speakerProfile(speakerProfile)
+                    .waitingType(InitiatorType.SPEAKER)
+                    .preferredFields(preferredFields)
+                    .preferredStyle(preferredStyle)
+                    .build();
+        } else {
+            ListenerProfile listenerProfile = listenerProfileRepository.findById(profileId)
+                    .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+            waitingQueue = WaitingQueue.builder()
+                    .listenerProfile(listenerProfile)
+                    .waitingType(InitiatorType.LISTENER)
+                    .preferredFields(preferredFields)
+                    .preferredStyle(preferredStyle)
+                    .build();
+        }
+
+        waitingQueueRepository.save(waitingQueue);
+
+    }
+
+    @Transactional
+    @Override
+    public void cancelWaiting(Long profileId, InitiatorType userType) {
+        Optional<WaitingQueue> cancelQueue;
+
+        if (userType == InitiatorType.SPEAKER) {
+            cancelQueue = waitingQueueRepository.findBySpeakerProfileIdAndActiveTrue(profileId);
+        } else {
+            cancelQueue = waitingQueueRepository.findByListenerProfileIdAndActiveTrue(profileId);
+        }
+
+        if (cancelQueue.isPresent()) {
+            WaitingQueue waitingQueue = cancelQueue.get();
+            waitingQueue.deactivate();
+            waitingQueueRepository.save(waitingQueue);
+
+        }
+    }
+
+    // 대기중인 유저
+    @Transactional(readOnly = true)
+    @Override
+    public List<WaitingProfile> getWaitingUsers(InitiatorType userType) {
+        List<WaitingQueue> waitingUsers = waitingQueueRepository
+                .findByWaitingTypeAndActiveOrderByCreatedAtAsc(userType, true);
+
+        return waitingUsers.stream()
+                .map(wq -> {
+                    if (userType == InitiatorType.SPEAKER) {
+                        SpeakerProfile speaker = wq.getSpeakerProfile();
+                        return WaitingProfile.builder()
+                                .profileId(speaker.getId())
+                                .nickname(speaker.getNickname())
+                                .profileImage(speaker.getProfileImage())
+                                .requestedFields(wq.getPreferredFields().stream()
+                                        .map(CounselingField::getTitle)
+                                        .collect(Collectors.toSet()))
+                                .preferredStyle(wq.getPreferredStyle() != null ? wq.getPreferredStyle().getTitle() : null)
+                                .waitingSince(wq.getCreatedAt())
+                                .build();
+                    } else {
+                        ListenerProfile listener = wq.getListenerProfile();
+                        return WaitingProfile.builder()
+                                .profileId(listener.getId())
+                                .nickname(listener.getNickname())
+                                .profileImage(listener.getProfileImage())
+                                .requestedFields(wq.getPreferredFields().stream()
+                                        .map(CounselingField::getTitle)
+                                        .collect(Collectors.toSet()))
+                                .preferredStyle(wq.getPreferredStyle() != null ? wq.getPreferredStyle().getTitle() : null)
+                                .waitingSince(wq.getCreatedAt())
+                                .build();
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    // 상태 업데이트
+    @Transactional
+    @Override
+    public void updateListenerStatus(Long listenerId, ListenerStatus status) {
+        ListenerProfile listener = listenerProfileRepository.findById(listenerId)
+                .orElseThrow(() -> new CustomException(ProfileErrorCode.PROFILE_NOT_FOUND));
+
+        // 레디스에 저장
+        redisTemplate.opsForValue().set(USER_STATUS_PREFIX + "listener:" + listenerId, status.name());
+
+        if (status == ListenerStatus.AVAILABLE) {
+            redisTemplate.opsForSet().add(LISTENERS_AVAILABLE, listenerId.toString());
+
+            Set<CounselingField> fields = listener.getCounselingFields().stream()
+                    .map(cf -> cf.getField())
+                    .collect(Collectors.toSet());
+
+            addToWaitingQueue(listenerId, InitiatorType.LISTENER, fields, listener.getCounselingStyle());
+        } else {
+            redisTemplate.opsForSet().remove(LISTENERS_AVAILABLE, listenerId.toString());
+
+            cancelWaiting(listenerId, InitiatorType.LISTENER);
+        }
+    }
+
+    @Transactional
+    @Override
+    public void updateSpeakerStatus(Long speakerId, boolean isAvailable,
+                                    Set<CounselingField> preferredFields, CounselingStyle preferredStyle) {
+
+        String status = isAvailable ? "WAITING" : "INACTIVE";
+        // 레디스에 저장
+        redisTemplate.opsForValue().set(USER_STATUS_PREFIX + "speaker:" + speakerId, status);
+
+        if (isAvailable) {
+            redisTemplate.opsForSet().add(SPEAKERS_AVAILABLE, speakerId.toString());
+
+            addToWaitingQueue(speakerId, InitiatorType.SPEAKER, preferredFields, preferredStyle);
+        } else {
+            redisTemplate.opsForSet().remove(SPEAKERS_AVAILABLE, speakerId.toString());
+
+            cancelWaiting(speakerId, InitiatorType.SPEAKER);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<WaitingQueue> findWaitingUsers(InitiatorType userType,
+                                               Set<CounselingField> preferredFields,
+                                               CounselingStyle preferredStyle) {
+        if (userType == InitiatorType.SPEAKER) {
+            return findWaitingSpeakers(preferredFields, preferredStyle);
+        } else {
+            return findWaitingListeners(preferredFields, preferredStyle);
+        }
+    }
+
+    // 조건에 맞는 사용자 찾기 todo : querydsl로 단순화
+    @Transactional(readOnly = true)
+    @Override
+    public List<WaitingQueue> findWaitingSpeakers(Set<CounselingField> preferredFields, CounselingStyle preferredStyle) {
+        if (preferredFields != null && !preferredFields.isEmpty() && preferredStyle != null) {
+            return waitingQueueRepository.findActiveSpeakersByFieldsAndStyle(preferredFields, preferredStyle);
+        } else if (preferredFields != null && !preferredFields.isEmpty()) {
+            return waitingQueueRepository.findActiveSpeakersByPreferredFields(preferredFields);
+        } else if (preferredStyle != null) {
+            return waitingQueueRepository.findByWaitingTypeAndActiveAndPreferredStyleOrderByCreatedAtAsc(
+                    InitiatorType.SPEAKER, true, preferredStyle);
+        } else {
+            return waitingQueueRepository.findByWaitingTypeAndActiveOrderByCreatedAtAsc(
+                    InitiatorType.SPEAKER, true);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<WaitingQueue> findWaitingListeners(Set<CounselingField> preferredFields, CounselingStyle preferredStyle) {
+        if (preferredFields != null && !preferredFields.isEmpty() && preferredStyle != null) {
+            return waitingQueueRepository.findActiveListenersByFieldsAndStyle(preferredFields, preferredStyle);
+        } else if (preferredFields != null && !preferredFields.isEmpty()) {
+            return waitingQueueRepository.findActiveListenersByPreferredFields(preferredFields);
+        } else if (preferredStyle != null) {
+            return waitingQueueRepository.findByWaitingTypeAndActiveAndPreferredStyleOrderByCreatedAtAsc(
+                    InitiatorType.LISTENER, true, preferredStyle);
+        } else {
+            return waitingQueueRepository.findByWaitingTypeAndActiveOrderByCreatedAtAsc(
+                    InitiatorType.LISTENER, true);
+        }
+    }
+
+    // 사용자 대기 중인지 확인
+    @Transactional(readOnly = true)
+    @Override
+    public boolean isUserWaiting(Long profileId, InitiatorType userType) {
+        if (userType == InitiatorType.SPEAKER) {
+            return waitingQueueRepository.findBySpeakerProfileIdAndActiveTrue(profileId).isPresent();
+        } else {
+            return waitingQueueRepository.findByListenerProfileIdAndActiveTrue(profileId).isPresent();
+        }
+    }
+
+
+    // 레디스 - 상담 가능한 유저
+    @Override
+    public Set<String> getAvailableUserIds(InitiatorType userType) {
+        String redisKey = userType == InitiatorType.SPEAKER ? SPEAKERS_AVAILABLE : LISTENERS_AVAILABLE;
+        return redisTemplate.opsForSet().members(redisKey);
+    }
+
+    // 레디스 - 사용자 상태
+    @Override
+    public String getUserStatus(Long profileId, InitiatorType userType) {
+        String userTypeStr = userType == InitiatorType.SPEAKER ? "speaker" : "listener";
+        return redisTemplate.opsForValue().get(USER_STATUS_PREFIX + userTypeStr + ":" + profileId);
+    }
+
+}

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -47,6 +48,11 @@ public class User extends BaseTimeEntity {
 
     @OneToOne(mappedBy = "user")
     private SpeakerProfile speakerProfile;
+
+    // 일일 매칭 제한 관련 필드 추가
+    private int dailyCancellationCount = 0;
+    private int dailyRejectionCount = 0;
+    private LocalDate lastActionResetDate;
 
     @Builder
     public User(String email, String password, RoleType role) {
@@ -90,5 +96,37 @@ public class User extends BaseTimeEntity {
     @VisibleForTesting
     public void setSpeakerProfileForTest(SpeakerProfile profile) {
         this.speakerProfile = profile;
+    }
+
+    // 매칭 관련 메서드 추가
+    public boolean addCancelCount() {
+        checkAndResetLimits();
+
+        if (dailyCancellationCount >= 3) {
+            return false; // 한도 초과
+        }
+
+        dailyCancellationCount++;
+        return true;
+    }
+
+    public boolean addRejectionCount() {
+        checkAndResetLimits();
+
+        if (dailyRejectionCount >= 3) {
+            return false; // 한도 초과
+        }
+
+        dailyRejectionCount++;
+        return true;
+    }
+
+    private void checkAndResetLimits() {
+        LocalDate today = LocalDate.now();
+        if (lastActionResetDate == null || !today.equals(lastActionResetDate)) {
+            dailyCancellationCount = 0;
+            dailyRejectionCount = 0;
+            lastActionResetDate = today;
+        }
     }
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/repository/ListenerRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/repository/ListenerRepository.java
@@ -1,14 +1,38 @@
 package com.mindmate.mindmate_server.user.repository;
 
+import com.mindmate.mindmate_server.user.domain.CounselingField;
+import com.mindmate.mindmate_server.user.domain.CounselingStyle;
 import com.mindmate.mindmate_server.user.domain.ListenerProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 @Repository
 public interface ListenerRepository extends JpaRepository<ListenerProfile, Long> {
     boolean existsByNickname(String nickname);
 
     List<ListenerProfile> findByCertificationUrlIsNotNull();
+
+    List<ListenerProfile> findByCounselingStyle(CounselingStyle counselingStyle);
+
+    // 특정 상담 분야
+    @Query("SELECT DISTINCT lp FROM ListenerProfile lp JOIN lp.counselingFields cf " +
+            "WHERE cf.field = :field")
+    List<ListenerProfile> findByField(@Param("field") CounselingField field);
+
+    // 여러 상담 분야 중 하나
+    @Query("SELECT DISTINCT lp FROM ListenerProfile lp JOIN lp.counselingFields cf " +
+            "WHERE cf.field IN :fields")
+    List<ListenerProfile> findByFields(@Param("fields") Set<CounselingField> fields);
+
+    // 특정 상담 분야 + 스타일
+    @Query("SELECT DISTINCT lp FROM ListenerProfile lp JOIN lp.counselingFields cf " +
+            "WHERE cf.field IN :fields AND lp.counselingStyle = :style")
+    List<ListenerProfile> findByFieldsAndStyle(
+            @Param("fields") Set<CounselingField> fields,
+            @Param("style") CounselingStyle style);
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/repository/SpeakerRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/repository/SpeakerRepository.java
@@ -1,5 +1,6 @@
 package com.mindmate.mindmate_server.user.repository;
 
+import com.mindmate.mindmate_server.user.domain.CounselingStyle;
 import com.mindmate.mindmate_server.user.domain.SpeakerProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,7 @@ import java.util.List;
 @Repository
 public interface SpeakerRepository extends JpaRepository<SpeakerProfile, Long> {
     boolean existsByNickname(String nickname);
+
+    // 상담 스타일
+    List<SpeakerProfile> findByPreferredCounselingStyle(CounselingStyle preferredCounselingStyle);
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#14 

## 🪐 작업 내용
- 매칭 & 대기열 엔티티 추가
- 매칭 관련 dto 추가
- 매칭 관련 에러코드 추가
- 매칭(자동/수동) & 대기열 로직 
- kafka 컨슈머 설정

## 추가로 구현할 내용
- 코드 리팩토링
- 테스트 코드
- querydsl 변경
- **채팅방 연결 부분**
- 인증부분 -> @AuthenticationPrincipal UserPrincipal principal로 바꾸기