### PR TITLE
[Feat#26] 로그인/회원가입 로직 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+spec:
+  ports:
+    - port: 2181
+      targetPort: 2181
+  selector:
+    app: zookeeper
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+spec:
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+        - image: confluentinc/cp-zookeeper:latest
+          name: zookeeper
+          env:
+            - name: ZOOKEEPER_CLIENT_PORT
+              value: "2181"
+          ports:
+            - containerPort: 2181
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+spec:
+  ports:
+    - port: 9092
+      targetPort: 9092
+    - port: 29092
+      targetPort: 29092
+  selector:
+    app: kafka
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+spec:
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - image: confluentinc/cp-kafka:latest
+          name: kafka
+          env:
+            - name: KAFKA_BROKER_ID
+              value: "1"
+            - name: KAFKA_ZOOKEEPER_CONNECT
+              value: "zookeeper:2181"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
+            - name: KAFKA_LISTENERS
+              value: "PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "PLAINTEXT"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+          ports:
+            - containerPort: 9092
+            - containerPort: 29092

--- a/k8s/mindmate-backend.yaml
+++ b/k8s/mindmate-backend.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mindmate-backend
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  selector:
+    app: mindmate-backend
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mindmate-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mindmate-backend
+  template:
+    metadata:
+      labels:
+        app: mindmate-backend
+    spec:
+      containers:
+        - name: mindmate-backend
+          image: docker.io/daehuijoe/mindmate:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_DATASOURCE_URL
+              value: jdbc:mysql://mysql:3306/mindmate?useSSL=false
+            - name: SPRING_DATASOURCE_USERNAME
+              value: mindmate
+            - name: SPRING_DATASOURCE_PASSWORD
+              value: mindmate12!
+            - name: SPRING_REDIS_HOST
+              value: redis
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: kafka:29092

--- a/k8s/mysql.yaml
+++ b/k8s/mysql.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+    app: mysql
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - image: mysql:8.0
+          name: mysql
+          env:
+            - name: MYSQL_DATABASE
+              value: mindmate
+            - name: MYSQL_USER
+              value: mindmate
+            - name: MYSQL_PASSWORD
+              value: mindmate12!
+            - name: MYSQL_ROOT_PASSWORD
+              value: root1234
+          ports:
+            - containerPort: 3306
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+          args:
+            - --character-set-server=utf8mb4
+            - --collation-server=utf8mb4_unicode_ci
+      volumes:
+        - name: mysql-data
+          persistentVolumeClaim:
+            claimName: mysql-data

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - image: redis:latest
+          name: redis
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: redis-data

--- a/k8s/tekton/pipeline.yaml
+++ b/k8s/tekton/pipeline.yaml
@@ -1,0 +1,59 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: mindmate-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+      description: 파이프라인 작업 간에 공유되는 작업 공간
+  params:
+    - name: git-url
+      type: string
+      description: Git 저장소 URL
+      default: "https://github.com/2025-ajou-capstone-mindmate/mindmate-backend.git"
+    - name: git-revision
+      type: string
+      description: Git 리비전(브랜치, 태그, SHA)
+      default: "develop"
+    - name: image-name
+      type: string
+      description: 빌드할 Docker 이미지 이름
+      default: "docker.io/daehuijoe/mindmate:latest" # todo: 이건 내 계쩡인데 공용 docker hub 계쩡을 만들어야 하나?
+    - name: app-namespace
+      type: string
+      description: 애플리케이션을 배포할 네임스페이스
+      default: "default"
+  tasks:
+    - name: fetch-source
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.git-revision)
+    - name: build-app
+      runAfter: ["fetch-source"]
+      taskRef:
+        name: build-spring-app
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: image-name
+          value: $(params.image-name)
+    - name: deploy-app
+      runAfter: ["build-app"]
+      taskRef:
+        name: deploy-app
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: image-name
+          value: $(params.image-name)
+        - name: app-namespace
+          value: $(params.app-namespace)

--- a/k8s/tekton/pvc.yaml
+++ b/k8s/tekton/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tekton-workspace
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/tekton/tasks/build-task.yaml
+++ b/k8s/tekton/tasks/build-task.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: build-spring-app
+spec:
+  workspaces:
+    - name: source
+      description: 소스 코드가 있는 작업 공간
+  params:
+    - name: image-name
+      type: string
+      description: 빌드할 Docker 이미지 이름
+      default: "docker.io/daehuijoe/mindmate:latest" # todo: 수정
+    - name: gradle-task
+      type: string
+      description: 실행할 Gradle 태스크
+      default: "clean bootJar"
+  steps:
+    - name: build-jar
+      image: gradle:7.6.1-jdk17
+      workingDir: $(workspaces.source.path)
+      script: |
+        echo "Building Spring Boot application..."
+        chmod +x ./gradlew
+        ./gradlew $(params.gradle-task) -x test
+        echo "Build completed."
+    - name: build-image
+      image: gcr.io/kaniko-project/executor:v1.9.1-debug
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: DOCKER_CONFIG
+          value: /tekton/home/.docker
+      script: |
+        echo "Building Docker image $(params.image-name)..."
+        /kaniko/executor --dockerfile=Dockerfile \
+                         --context=$(workspaces.source.path) \
+                         --destination=$(params.image-name) \
+                         --skip-tls-verify
+        echo "Image build completed."

--- a/k8s/tekton/tasks/deploy-task.yaml
+++ b/k8s/tekton/tasks/deploy-task.yaml
@@ -1,0 +1,40 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: deploy-app
+spec:
+  workspaces:
+    - name: source
+      description: 배포 매니페스트가 있는 작업 공간
+  params:
+    - name: image-name
+      type: string
+      description: 배포할 Docker 이미지 이름
+    - name: app-namespace
+      type: string
+      description: 애플리케이션을 배포할 네임스페이스
+      default: "default"
+  steps:
+    - name: deploy-infra
+      image: bitnami/kubectl:latest
+      script: |
+        echo "Deploying infrastructure components..."
+        # MySQL, Redis, Kafka 등의 인프라 컴포넌트 배포
+        kubectl apply -f $(workspaces.source.path)/k8s/mysql.yaml -n $(params.app-namespace)
+        kubectl apply -f $(workspaces.source.path)/k8s/redis.yaml -n $(params.app-namespace)
+        kubectl apply -f $(workspaces.source.path)/k8s/kafka.yaml -n $(params.app-namespace)
+        echo "Infrastructure deployment completed."
+    - name: update-image
+      image: bitnami/kubectl:latest
+      script: |
+        echo "Updating application image to $(params.image-name)..."
+        # 애플리케이션 배포 YAML에서 이미지 업데이트
+        sed -i "s|image:.*|image: $(params.image-name)|g" $(workspaces.source.path)/k8s/mindmate-backend.yaml
+        kubectl apply -f $(workspaces.source.path)/k8s/mindmate-backend.yaml -n $(params.app-namespace)
+        echo "Application deployment completed."
+    - name: check-deployment
+      image: bitnami/kubectl:latest
+      script: |
+        echo "Checking deployment status..."
+        kubectl rollout status deployment/mindmate-backend -n $(params.app-namespace) --timeout=180s
+        echo "Deployment is ready."

--- a/k8s/tekton/tasks/git-clone-task.yaml
+++ b/k8s/tekton/tasks/git-clone-task.yaml
@@ -1,0 +1,34 @@
+## 기본값 develop -> 코드 변경이 발생할 때마다 자동으로 빌드 및 배포
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+spec:
+  workspaces:
+    - name: output
+      description: 저장소가 클론될 작업 공간
+  params:
+    - name: url
+      type: string
+      description: Git 저장소 URL
+    - name: revision
+      type: string
+      description: 체크아웃할 Git 리비전(브랜치, 태그, SHA 등)
+      default: "develop"
+    - name: deleteExisting
+      type: string
+      description: 클론하기 전에 기존 디렉토리를 삭제할지 여부
+      default: "true"
+  steps:
+    - name: clone
+      image: alpine/git
+      script: |
+        if [ "$(params.deleteExisting)" = "true" ] && [ -d "/workspace/output/" ]; then
+          rm -rf /workspace/output/*
+          rm -rf /workspace/output/.[!.]*
+        fi
+        git clone -b $(params.revision) $(params.url) /workspace/output/
+        cd /workspace/output/
+        echo "Repository contents:"
+        ls -la

--- a/k8s/tekton/triggers.yaml
+++ b/k8s/tekton/triggers.yaml
@@ -1,0 +1,64 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: mindmate-trigger-template
+spec:
+  params:
+    - name: gitrepositoryurl
+      description: Git 저장소 URL
+    - name: gitrevision
+      description: Git 리비전(브랜치, 태그, SHA)
+    - name: namespace
+      description: 파이프라인이 실행될 네임스페이스
+      default: "default"
+    - name: image-name
+      description: 빌드할 Docker 이미지 이름
+      default: "docker.io/daehuijoe/mindmate:latest"
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: mindmate-pipeline-run-
+        namespace: $(tt.params.namespace)
+      spec:
+        pipelineRef:
+          name: mindmate-pipeline
+        workspaces:
+          - name: shared-workspace
+            persistentVolumeClaim:
+              claimName: tekton-workspace
+        params:
+          - name: git-url
+            value: $(tt.params.gitrepositoryurl)
+          - name: git-revision
+            value: $(tt.params.gitrevision)
+          - name: image-name
+            value: $(tt.params.image-name)
+          - name: app-namespace
+            value: $(tt.params.namespace)
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: mindmate-trigger-binding
+spec:
+  params:
+    - name: gitrepositoryurl
+      value: $(body.repository.clone_url)
+    - name: gitrevision
+      value: $(body.ref)
+    - name: namespace
+      value: default
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: mindmate-event-listener
+spec:
+  serviceAccountName: tekton-triggers-sa
+  triggers:
+    - name: github-push
+      bindings:
+        - ref: mindmate-trigger-binding
+      template:
+        ref: mindmate-trigger-template

--- a/src/main/java/com/mindmate/mindmate_server/auth/controller/AuthController.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/controller/AuthController.java
@@ -37,9 +37,9 @@ public class AuthController {
 
     @Operation(summary = "이메일 인증", description = "이메일 인증 토큰을 검증합니다.")
     @GetMapping("/email/verify")
-    public ResponseEntity<Void> verifyEmail(@RequestParam String token) {
-        authService.verifyEmail(token);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<TokenResponse> verifyEmail(@RequestParam String token) {
+        TokenResponse response = authService.verifyEmail(token);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")

--- a/src/main/java/com/mindmate/mindmate_server/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/dto/SignUpRequest.java
@@ -20,22 +20,22 @@ public class SignUpRequest {
     @NotBlank(message = "확인 비밀번호를 입력해주세요.")
     private String confirmPassword;
 
-    @NotBlank(message = "닉네임을 입력해주세요.")
-    @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
-    private String nickname;
-
-    @NotBlank(message = "학과를 입력해주세요.")
-    @Size(max = 20, message = "학과는 20자 이하여야 합니다.")
-    private String department;
-
-    private String imgUrl;
-
-    @NotNull(message = "입학 연도를 입력해주세요.")
-    private Integer entranceTime;
-
-    private boolean graduation;
-
     @AssertTrue(message = "개인 정보 동의를 체크해주세요.")
     private boolean agreeToTerm;
+
+//    @NotBlank(message = "닉네임을 입력해주세요.")
+//    @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
+//    private String nickname;
+//
+//    @NotBlank(message = "학과를 입력해주세요.")
+//    @Size(max = 20, message = "학과는 20자 이하여야 합니다.")
+//    private String department;
+//
+//    private String imgUrl;
+//
+//    @NotNull(message = "입학 연도를 입력해주세요.")
+//    private Integer entranceTime;
+//
+//    private boolean graduation;
 
 }

--- a/src/main/java/com/mindmate/mindmate_server/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/dto/SignUpRequest.java
@@ -1,19 +1,17 @@
 package com.mindmate.mindmate_server.auth.dto;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.*;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignUpRequest {
     @NotBlank(message = "이메일을 입력해주세요.")
-    @Email
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
@@ -23,24 +21,21 @@ public class SignUpRequest {
     private String confirmPassword;
 
     @NotBlank(message = "닉네임을 입력해주세요.")
+    @Size(max = 10, message = "닉네임은 10자 이하여야 합니다.")
     private String nickname;
 
     @NotBlank(message = "학과를 입력해주세요.")
+    @Size(max = 20, message = "학과는 20자 이하여야 합니다.")
     private String department;
 
     private String imgUrl;
 
-    @NotBlank(message = "입학 연도를 입력해주세요.")
-    private LocalDateTime entranceTime;
+    @NotNull(message = "입학 연도를 입력해주세요.")
+    private Integer entranceTime;
 
-    @NotBlank(message = "졸업 여부를 체크해주세요.")
     private boolean graduation;
 
+    @AssertTrue(message = "개인 정보 동의를 체크해주세요.")
+    private boolean agreeToTerm;
 
-    @Builder
-    public SignUpRequest(String email, String password, String confirmPassword) {
-        this.email = email;
-        this.password = password;
-        this.confirmPassword = confirmPassword;
-    }
 }

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/AuthService.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/AuthService.java
@@ -7,7 +7,6 @@ import com.mindmate.mindmate_server.auth.dto.TokenResponse;
 
 public interface AuthService {
 
-
     void registerUser(SignUpRequest request);
 
     void verifyEmail(String token);

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/AuthService.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/AuthService.java
@@ -9,7 +9,7 @@ public interface AuthService {
 
     void registerUser(SignUpRequest request);
 
-    void verifyEmail(String token);
+    TokenResponse verifyEmail(String token);
 
     LoginResponse login(LoginRequest request);
 

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/AuthServiceImpl.java
@@ -117,7 +117,7 @@ public class AuthServiceImpl implements AuthService {
         }
 
         user.verifyEmail();
-//        user.updateRole(RoleType.ROLE_USER);
+        user.updateRole(RoleType.ROLE_USER);
 //        userService.save(user);
     }
 

--- a/src/main/java/com/mindmate/mindmate_server/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/service/AuthServiceImpl.java
@@ -57,6 +57,7 @@ public class AuthServiceImpl implements AuthService {
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .role(RoleType.ROLE_UNVERIFIED)
+                .agreedToTerms(request.isAgreeToTerm())
                 .build();
 
         user.generateVerificationToken();

--- a/src/main/java/com/mindmate/mindmate_server/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/mindmate/mindmate_server/auth/util/JwtTokenProvider.java
@@ -57,6 +57,7 @@ public class JwtTokenProvider {
 
         String username = switch (user.getCurrentRole()) {
             case ROLE_UNVERIFIED, ROLE_USER -> user.getEmail();
+            case ROLE_PROFILE -> user.getProfile().getNickname();
             case ROLE_ADMIN -> "admin:" + user.getEmail();
         };
 

--- a/src/main/java/com/mindmate/mindmate_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.apache.catalina.filters.RateLimitFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,6 +31,7 @@ import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/mindmate/mindmate_server/global/config/SecurityConfig.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/config/SecurityConfig.java
@@ -66,16 +66,18 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                     .requestMatchers(
                             "/ws/**",
-                            "/api/**",
-//                            "/api/auth/register",
-//                            "/api/auth/login",
-//                            "/api/auth/verify-email",
-//                            "/api/auth/resend-verification",
+                            "/api/auth/register",
+                            "/api/auth/login",
+                            "/api/auth/email/verify",
+                            "/api/auth/email/resend",
                             "/swagger-ui/**",
                             "/swagger-resources/**",
                             "/v3/api-docs/**"
                             ).permitAll() // 향후 수정 (api 접근, role 별 접근 등)
-                    .anyRequest().authenticated())
+                        .requestMatchers("/api/profile/**").hasAnyAuthority("ROLE_USER", "ROLE_PROFILE", "ROLE_ADMIN")
+                        .requestMatchers("/api/chat/**", "/ws/**").hasAnyAuthority("ROLE_PROFILE", "ROLE_ADMIN")
+                        .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
+                        .anyRequest().authenticated())
 //                .addFilterBefore(new RequestLoggingFilter(), UsernamePasswordAuthenticationFilter.class) // 모든 요청 로깅
 //                .addFilterBefore(new RateLimitFilter(), UsernamePasswordAuthenticationFilter.class) // 초당 50개 요청 제한
 //                .addFilterBefore(new XssFilter(), UsernamePasswordAuthenticationFilter.class) // XSS 공격 방지

--- a/src/main/java/com/mindmate/mindmate_server/global/exception/AuthErrorCode.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/exception/AuthErrorCode.java
@@ -38,7 +38,8 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 비밀번호입니다."),
 
     // 인증 여부
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다");
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다"), 
+    PROFILE_NOT_REGISTER(HttpStatus.FORBIDDEN, "프로필 등록이 완성되지 않았습니다" );
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/mindmate/mindmate_server/global/exception/AuthErrorCode.java
+++ b/src/main/java/com/mindmate/mindmate_server/global/exception/AuthErrorCode.java
@@ -21,6 +21,10 @@ public enum AuthErrorCode implements ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 회원가입 된 이메일입니다"),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 비밀번호입니다"),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "두 비밀번호가 일치하지 않습니다"),
+    INVALID_ENTRANCE_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 입학 연도 정보입니다."),
+    INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "유효하지 않은 닉네임입니다"),
+    INVALID_DEPARTMENT(HttpStatus.BAD_REQUEST, "유효하지 않은 학과 정보입니다"),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다"),
 
     // 이메일 인증
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송을 실패하였습니다"),

--- a/src/main/java/com/mindmate/mindmate_server/user/controller/ProfileController.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/controller/ProfileController.java
@@ -1,6 +1,5 @@
 package com.mindmate.mindmate_server.user.controller;
 
-import com.mindmate.mindmate_server.auth.util.SecurityUtil;
 import com.mindmate.mindmate_server.chat.domain.UserPrincipal;
 import com.mindmate.mindmate_server.user.dto.*;
 import com.mindmate.mindmate_server.user.service.ProfileService;

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/Profile.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/Profile.java
@@ -30,7 +30,7 @@ public class Profile extends BaseTimeEntity {
     private String department;
 
     @Column(nullable = false)
-    private LocalDateTime entranceTime;
+    private Integer entranceTime;
 
     @Column(nullable = false)
     private boolean graduation;
@@ -47,7 +47,7 @@ public class Profile extends BaseTimeEntity {
     private Set<String> evaluationTags = new HashSet<>();
 
     @Builder
-    public Profile(User user, String nickname, String department, LocalDateTime entranceTime, boolean graduation, String profileImage) {
+    public Profile(User user, String nickname, String department, Integer entranceTime, boolean graduation, String profileImage) {
         this.user = user;
         this.profileImage = profileImage;
         this.nickname = nickname;
@@ -80,7 +80,7 @@ public class Profile extends BaseTimeEntity {
         this.department = department;
     }
 
-    public void updateEntranceTime(LocalDateTime entranceTime) {
+    public void updateEntranceTime(Integer entranceTime) {
         this.entranceTime = entranceTime;
     }
 

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/RoleType.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/RoleType.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum RoleType {
     ROLE_UNVERIFIED("ROLE_UNVERIFIED", "이메일 인증 안한 사용자"),
     ROLE_USER("ROLE_USER", "프로필 입력 안한 사용자"),
+    ROLE_PROFILE("ROLE_PROFILE", "프로필 입력 한 사용자"),
     ROLE_ADMIN("ROLE_MANGER", "관리자");
 
     private final String key;

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = {"sentMessages"})
+@ToString(exclude = {"sentMessages", "listenerRooms", "speakerRooms"})
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/domain/User.java
@@ -54,11 +54,14 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL)
     private List<ChatMessage> sentMessages = new ArrayList<>();
 
-    @OneToMany(mappedBy = "listener")
+    @OneToMany(mappedBy = "listener") // 사용자 삭제되더라도 채팅방 값 존재
     private List<ChatRoom> listenerRooms = new ArrayList<>();
 
     @OneToMany(mappedBy = "speaker")
     private List<ChatRoom> speakerRooms = new ArrayList<>();
+    
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private Profile profile;
 
     // 일일 매칭 제한 관련 필드 추가
     private int dailyCancellationCount = 0;

--- a/src/main/java/com/mindmate/mindmate_server/user/dto/ProfileCreateRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/dto/ProfileCreateRequest.java
@@ -11,6 +11,6 @@ public class ProfileCreateRequest {
     private String nickname;
     private String profileImage;
     private String department;
-    private LocalDateTime entranceTime;
+    private Integer entranceTime;
     private boolean graduation;
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/dto/ProfileDetailResponse.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/dto/ProfileDetailResponse.java
@@ -20,7 +20,7 @@ public class ProfileDetailResponse {
     private String nickname;
     private String profileImage;
     private String department;
-    private LocalDateTime entranceTime;
+    private Integer entranceTime;
     private boolean graduation;
 
     // 활동 정보

--- a/src/main/java/com/mindmate/mindmate_server/user/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/dto/ProfileUpdateRequest.java
@@ -11,7 +11,7 @@ public class ProfileUpdateRequest {
     private String nickname;
     private String profileImage;
     private String department;
-    private LocalDateTime entranceTime;
+    private Integer entranceTime;
     private Boolean graduation;
 }
 

--- a/src/main/java/com/mindmate/mindmate_server/user/repository/UserRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByVerificationToken(String token);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/repository/UserRepository.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/repository/UserRepository.java
@@ -14,5 +14,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByVerificationToken(String token);
 
-    boolean existsByNickname(String nickname);
+//    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/mindmate/mindmate_server/user/service/ProfileServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/ProfileServiceImpl.java
@@ -5,14 +5,13 @@ import com.mindmate.mindmate_server.global.exception.ProfileErrorCode;
 import com.mindmate.mindmate_server.review.domain.Review;
 import com.mindmate.mindmate_server.review.dto.ReviewResponse;
 import com.mindmate.mindmate_server.review.repository.ReviewRepository;
-import com.mindmate.mindmate_server.user.domain.*;
+import com.mindmate.mindmate_server.user.domain.Profile;
+import com.mindmate.mindmate_server.user.domain.User;
 import com.mindmate.mindmate_server.user.dto.*;
 import com.mindmate.mindmate_server.user.repository.ProfileRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/mindmate/mindmate_server/user/service/ProfileServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/ProfileServiceImpl.java
@@ -6,6 +6,7 @@ import com.mindmate.mindmate_server.review.domain.Review;
 import com.mindmate.mindmate_server.review.dto.ReviewResponse;
 import com.mindmate.mindmate_server.review.repository.ReviewRepository;
 import com.mindmate.mindmate_server.user.domain.Profile;
+import com.mindmate.mindmate_server.user.domain.RoleType;
 import com.mindmate.mindmate_server.user.domain.User;
 import com.mindmate.mindmate_server.user.dto.*;
 import com.mindmate.mindmate_server.user.repository.ProfileRepository;
@@ -83,6 +84,7 @@ public class ProfileServiceImpl implements ProfileService {
                 .build();
 
         profileRepository.save(profile);
+        user.updateRole(RoleType.ROLE_PROFILE);
 
         return ProfileResponse.of(profile.getId(), profile.getNickname(), "프로필이 생성되었습니다.");
     }

--- a/src/main/java/com/mindmate/mindmate_server/user/service/UserService.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/UserService.java
@@ -9,7 +9,7 @@ public interface UserService {
 
     boolean existsByEmail(String email);
 
-    boolean existsByNickname(String nickname);
+//    boolean existsByNickname(String nickname);
 
     void save(User user);
 

--- a/src/main/java/com/mindmate/mindmate_server/user/service/UserService.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/UserService.java
@@ -3,13 +3,13 @@ package com.mindmate.mindmate_server.user.service;
 import com.mindmate.mindmate_server.user.domain.User;
 
 public interface UserService {
-//    User getCurrentUser();
-
     User findUserById(Long userId);
 
     User findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 
     void save(User user);
 

--- a/src/main/java/com/mindmate/mindmate_server/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/UserServiceImpl.java
@@ -1,6 +1,5 @@
 package com.mindmate.mindmate_server.user.service;
 
-import com.mindmate.mindmate_server.auth.util.SecurityUtil;
 import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
 import com.mindmate.mindmate_server.global.exception.CustomException;
 import com.mindmate.mindmate_server.global.exception.UserErrorCode;
@@ -31,10 +30,10 @@ public class UserServiceImpl implements UserService {
         return userRepository.existsByEmail(email);
     }
 
-    @Override
-    public boolean existsByNickname(String nickname) {
-        return userRepository.existsByNickname(nickname);
-    }
+//    @Override
+//    public boolean existsByNickname(String nickname) {
+//        return userRepository.existsByNickname(nickname);
+//    }
 
     @Override
     public void save(User user) {

--- a/src/main/java/com/mindmate/mindmate_server/user/service/UserServiceImpl.java
+++ b/src/main/java/com/mindmate/mindmate_server/user/service/UserServiceImpl.java
@@ -13,12 +13,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
-//    private final SecurityUtil securityUtil;
-
-//    @Override
-//    public User getCurrentUser() {
-//        return securityUtil.getCurrentUser();
-//    }
 
     @Override
     public User findUserById(Long userId) {
@@ -35,6 +29,11 @@ public class UserServiceImpl implements UserService {
     @Override
     public boolean existsByEmail(String email) {
         return userRepository.existsByEmail(email);
+    }
+
+    @Override
+    public boolean existsByNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
     }
 
     @Override

--- a/src/test/java/com/mindmate/mindmate_server/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/service/AuthServiceTest.java
@@ -1,519 +1,519 @@
-//package com.mindmate.mindmate_server.auth.service;
-//
-//import com.mindmate.mindmate_server.auth.dto.*;
-//import com.mindmate.mindmate_server.auth.util.JwtTokenProvider;
-//import com.mindmate.mindmate_server.auth.util.PasswordValidator;
-//import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
-//import com.mindmate.mindmate_server.global.exception.CustomException;
-//import com.mindmate.mindmate_server.user.domain.RoleType;
-//import com.mindmate.mindmate_server.user.domain.User;
-//import com.mindmate.mindmate_server.user.service.UserService;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.redis.core.RedisTemplate;
-//import org.springframework.data.redis.core.ValueOperations;
-//import org.springframework.security.crypto.password.PasswordEncoder;
-//
-//import java.time.LocalDateTime;
-//import java.util.Map;
-//
-//import static com.mindmate.mindmate_server.auth.service.AuthServiceImpl.RESEND_LIMIT_MINUTES;
-//import static com.mindmate.mindmate_server.auth.service.LoginAttemptService.MAX_ATTEMPTS;
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//class AuthServiceTest {
-//    @Mock private UserService userService;
-//    @Mock private TokenService tokenService;
-//    @Mock private EmailService emailService;
-//    @Mock private JwtTokenProvider jwtTokenProvider;
-//    @Mock private LoginAttemptService loginAttemptService;
-//    @Mock private PasswordValidator passwordValidator;
-//    @Mock private RedisTemplate<String, String> redisTemplate;
-//    @Mock private ValueOperations<String, String> valueOperations;
-//    @Mock private PasswordEncoder passwordEncoder;
-//
-//    @InjectMocks
-//    private AuthServiceImpl authService;
-//
-//    @BeforeEach
-//    void setup() {
-//        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-//    }
-//
-//    @Nested
-//    @DisplayName("회원가입 테스트")
-//    class RegisterUserTest {
-//
-//        @Test
-//        @DisplayName("정상적인 회원가입 성공")
-//        void registerUser_Success() {
-//            // given
-//            SignUpRequest request = new SignUpRequest("test@email.com", "password123", "password123");
-//            when(userService.existsByEmail(anyString())).thenReturn(false);
-//            when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
-//
-//            // when
-//            authService.registerUser(request);
-//
-//            // then
-//            verify(userService).existsByEmail(request.getEmail());
-//            verify(passwordValidator).validatePassword(request.getPassword());
-//            verify(userService).save(any(User.class));
-//            verify(emailService).sendVerificationEmail(any(User.class), anyString());
-//        }
-//
-//        @Test
-//        @DisplayName("중복 이메일")
-//        void registerUser_DuplicateEmail() {
-//            // given
-//            SignUpRequest request = new SignUpRequest("test@email.com", "password123", "password123");
-//            when(userService.existsByEmail(anyString())).thenReturn(true);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.registerUser(request));
-//            verify(userService).existsByEmail(request.getEmail());
-//        }
-//
-//        @Test
-//        @DisplayName("비밀번호 검증 실패")
-//        void registerUser_PasswordMismatch() {
-//            // given
-//            SignUpRequest request = new SignUpRequest("test@email.com", "password123", "password456");
-//            doThrow(new CustomException(AuthErrorCode.PASSWORD_MISMATCH))
-//                    .when(passwordValidator)
-//                    .validatePasswordMatch(request.getPassword(), request.getConfirmPassword());
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.registerUser(request));
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("이메일 재전송")
-//    class ResendVerificationEmail {
-//        @Test
-//        @DisplayName("정상 재전송")
-//        void resendVerificationEmail_Success() {
-//            // given
-//            String email = "test@email.com";
-//            String verificationToken = "test-token";
-//            User user = mock(User.class);
-//
-//            when(userService.findByEmail(email)).thenReturn(user);
-//            when(user.isEmailVerified()).thenReturn(false);
-//            when(user.getVerificationToken()).thenReturn(verificationToken);
-//            when(valueOperations.get(anyString())).thenReturn(null);
-//
-//            // when
-//            authService.resendVerificationEmail(email);
-//
-//            // then
-//            verify(user).getVerificationToken();
-////            verify(userService).save(user);
-//            verify(emailService).sendVerificationEmail(eq(user), eq(verificationToken));
-//        }
-//
-//        @Test
-//        @DisplayName("이미 인증된 이메일")
-//        void resendVerificationEmail_AlreadyVerified() {
-//            // given
-//            String email = "test@email.com";
-//            User user = mock(User.class);
-//
-//            when(userService.findByEmail(email)).thenReturn(user);
-//            when(user.isEmailVerified()).thenReturn(true);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.resendVerificationEmail(email));
-//        }
-//
-//        @Test
-//        @DisplayName("재전송 제한 시간")
-//        void resendVerificationEmail_TooFrequent() {
-//            // given
-//            String email = "test@email.com";
-//            User user = mock(User.class);
-//
-//            when(userService.findByEmail(email)).thenReturn(user);
-//            when(user.isEmailVerified()).thenReturn(false);
-//            when(valueOperations.get(anyString()))
-//                    .thenReturn(LocalDateTime.now().toString());
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.resendVerificationEmail(email));
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("이메일 인증 테스트")
-//    class VerifyEmailTest {
-//        @Test
-//        @DisplayName("정상적인 이메일 인증 성공")
-//        void verifyEmail_Success() {
-//            // given
-//            String token = "valid-token";
-//            User user = mock(User.class);
-//
-//            when(userService.findVerificationToken(token)).thenReturn(user);
-//            when(user.getVerificationToken()).thenReturn(token);
-//            when(user.isTokenExpired()).thenReturn(false);
-//
-//            // when
-//            authService.verifyEmail(token);
-//
-//            // then
-//            verify(userService).findVerificationToken(token);
-//            verify(user).verifyEmail();
-//            verify(user).updateRole(RoleType.ROLE_USER);
-////            verify(userService).save(user); 영속성
-//        }
-//
-//        @Test
-//        @DisplayName("잘못된 토큰으로 인증 시도")
-//        void verifyEmail_InvalidToken() {
-//            // given
-//            String token = "invalid-token";
-//            when(userService.findVerificationToken(token)).thenReturn(null);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.verifyEmail(token));
-//        }
-//
-//        @Test
-//        @DisplayName("만료된 토큰으로 인증 시도")
-//        void verifyEmail_ExpiredToken() {
-//            // given
-//            String token = "expired-token";
-//            User user = mock(User.class);
-//
-//            when(userService.findVerificationToken(token)).thenReturn(user);
-//            when(user.getVerificationToken()).thenReturn(token);
-//            when(user.isTokenExpired()).thenReturn(true);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.verifyEmail(token));
-//        }
-//
-//        @Test
-//        @DisplayName("재전송 제한 시간 초과하지 않은 경우")
-//        void resendVerificationEmail_TooFrequent() {
-//            // given
-//            String email = "test@email.com";
-//            User user = mock(User.class);
-//
-//            LocalDateTime recentRequestTime = LocalDateTime.now().minusMinutes(RESEND_LIMIT_MINUTES - 1);
-//            when(userService.findByEmail(email)).thenReturn(user);
-//            when(user.isEmailVerified()).thenReturn(false);
-//
-//            when(valueOperations.get(anyString())).thenReturn(recentRequestTime.toString());
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.resendVerificationEmail(email));
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("로그인")
-//    class Login {
-//        @Test
-//        @DisplayName("정상 로그인")
-//        void login_Success() {
-//            // given
-//            LoginRequest request = new LoginRequest("test@email.com", "password123");
-//            User user = mock(User.class);
-//
-//            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
-//            when(userService.findByEmail(request.getEmail())).thenReturn(user);
-//            when(user.isEmailVerified()).thenReturn(true);
-//            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(true);
-//
-//            String accessToken = "access-token";
-//            String refreshToken = "refresh-token";
-//
-//            when(jwtTokenProvider.generateToken(any(User.class))).thenReturn(accessToken);
-//            when(jwtTokenProvider.generateRefreshToken(any(User.class), anyString())).thenReturn(refreshToken);
-//
-//            // when
-//            LoginResponse response = authService.login(request);
-//
-//            // then
-//            assertNotNull(response);
-//            assertEquals(accessToken, response.getAccessToken());
-//            assertEquals(refreshToken, response.getRefreshToken());
-//
-//            verify(loginAttemptService).loginSucceeded(request.getEmail());
-//        }
-//
-//        @Test
-//        @DisplayName("계정 잠금 상태에서 로그인 시도")
-//        void login_AccountLocked() {
-//            // given
-//            LoginRequest request = new LoginRequest("test@email.com", "password123");
-//            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(true);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.login(request));
-//        }
-//
-//        @Test
-//        @DisplayName("이메일 미인증 상태에서 로그인 시도")
-//        void login_EmailNotVerified() {
-//            // given
-//            LoginRequest request = new LoginRequest("test@email.com", "password123");
-//            User user = mock(User.class);
-//
-//            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
-//            when(userService.findByEmail(request.getEmail())).thenReturn(user);
-//            when(user.isEmailVerified()).thenReturn(false);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.login(request));
-//        }
-//
-//        @Test
-//        @DisplayName("비밀번호 불일치 로그인 실패")
-//        void login_PasswordMismatch() {
-//            // given
-//            LoginRequest request = new LoginRequest("test@email.com", "wrong-password");
-//            User user = mock(User.class);
-//
-//            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
-//            when(userService.findByEmail(request.getEmail())).thenReturn(user);
-//            when(user.isEmailVerified()).thenReturn(true);
-//            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(false);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.login(request));
-//            verify(loginAttemptService).loginFailed(request.getEmail());
-//        }
-//
-//        @Test
-//        @DisplayName("프로필 작성이 필요한 경우 메시지 반환")
-//        void login_ProfileMessageNeeded() {
-//            // given
-//            LoginRequest request = new LoginRequest("test@email.com", "password123");
-//            User user = mock(User.class);
-//
-//            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
-//            when(userService.findByEmail(request.getEmail())).thenReturn(user);
-//            when(user.isEmailVerified()).thenReturn(true);
-//            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(true);
-//            when(user.getCurrentRole()).thenReturn(RoleType.ROLE_USER);
-//
-//            String accessToken = "access-token";
-//            String refreshToken = "refresh-token";
-//
-//            when(jwtTokenProvider.generateToken(user)).thenReturn(accessToken);
-//            when(jwtTokenProvider.generateRefreshToken(eq(user), anyString())).thenReturn(refreshToken);
-//
-//            // when
-//            LoginResponse response = authService.login(request);
-//
-//            // then
-//            assertNotNull(response);
-//            assertEquals("프로필 작성이 필요합니다.", response.getMessage());
-//        }
-//
-//        @Test
-//        @DisplayName("로그인 시도가 횟수 남지 않아 계정이 잠긴 경우")
-//        void login_AccountLockedAfterMaxAttempts() {
-//            // given
-//            LoginRequest request = new LoginRequest("test@email.com", "wrong-password");
-//            User user = mock(User.class);
-//
-//            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
-//            when(userService.findByEmail(request.getEmail())).thenReturn(user);
-//            when(user.isEmailVerified()).thenReturn(true);
-//            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(false);
-//            when(loginAttemptService.getCurrentAttempts(request.getEmail())).thenReturn(MAX_ATTEMPTS);
-//
-//            // when & then
-//            CustomException exception = assertThrows(CustomException.class, () -> authService.login(request));
-//
-//            assertEquals(AuthErrorCode.ACCOUNT_LOCKED, exception.getErrorCode());;
-//            Map<String, Object> details = (Map<String, Object>) exception.getDetails();
-//            assertNotNull(details);
-//            assertEquals(0, details.get("remainingAttempts"));
-//
-//            verify(loginAttemptService).loginFailed(request.getEmail());
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("로그아웃 테스트")
-//    class LogoutTest {
-//        @Test
-//        @DisplayName("정상적인 로그아웃 성공")
-//        void logout_Success() {
-//            // given
-//            String token = "valid-access-token";
-//            Long userId = 1L;
-//
-//            when(jwtTokenProvider.getUserIdFromToken(token)).thenReturn(userId);
-//
-//            // when
-//            authService.logout(token);
-//
-//            // then
-//            verify(tokenService).addToBlackList(token);
-//            verify(tokenService).invalidateRefreshToken(userId);
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("토큰 갱신 테스트")
-//    class RefreshTest {
-//        @Test
-//        @DisplayName("정상적인 토큰 갱신 성공")
-//        void refresh_Success() {
-//            // given
-//            String refreshToken = "valid-refresh-token";
-//            String accessToken = "old-access-token";
-//
-//            Long userId = 1L;
-//            User user = mock(User.class);
-//            TokenData tokenData = TokenData.of(refreshToken, "token-family");
-//
-//            String newAccessToken = "new-access-token";
-//            String newRefreshToken = "new-refresh-token";
-//
-//            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
-//            when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
-//            when(jwtTokenProvider.getTokenTypeFromToken(refreshToken)).thenReturn("REFRESH");
-//            when(userService.findUserById(userId)).thenReturn(user);
-//            when(jwtTokenProvider.getTokenFamilyFromToken(refreshToken)).thenReturn("token-family");
-//            when(tokenService.getRefreshToken(userId)).thenReturn(tokenData);
-//
-//            when(jwtTokenProvider.generateToken(user)).thenReturn(newAccessToken);
-//            when(jwtTokenProvider.generateRefreshToken(eq(user), anyString())).thenReturn(newRefreshToken);
-//
-//            // when
-//            TokenResponse response = authService.refresh(refreshToken, accessToken);
-//
-//            // then
-//            assertNotNull(response);
-//            assertEquals(newAccessToken, response.getAccessToken());
-//            assertEquals(newRefreshToken, response.getRefreshToken());
-//
-//            verify(tokenService).addToBlackList(refreshToken);
-//            verify(tokenService).saveRefreshToken(eq(userId), eq(newRefreshToken), anyString());
-//        }
-//
-//        @Test
-//        @DisplayName("리프레시 토큰 재사용 감지")
-//        void refresh_TokenReuseDetected() {
-//            // given
-//            String refreshToken = "valid-refresh-token";
-//            Long userId = 1L;
-//
-////            TokenData tokenData = null;
-//
-//            setupRefreshMocks(refreshToken, userId, null);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
-//            verify(tokenService).invalidateRefreshToken(userId);
-//        }
-//
-//        @Test
-//        @DisplayName("저장된 토큰 데이터가 null인 경우 예외 발생")
-//        void refresh_StoredTokenDataNull() {
-//            // given
-//            String refreshToken = "valid-refresh-token";
-//            Long userId = 1L;
-//
-//            setupRefreshMocks(refreshToken, userId, null);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
-//        }
-//
-//        @Test
-//        @DisplayName("토큰 패밀리가 일치하지 않는 경우 예외 발생")
-//        void refresh_TokenFamilyMismatch() {
-//            // given
-//            String refreshToken = "valid-refresh-token";
-//            Long userId = 1L;
-//            TokenData tokenData = TokenData.of("refresh-token", "different-family");
-//
-//            setupRefreshMocks(refreshToken, userId, tokenData);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
-//        }
-//
-//        @Test
-//        @DisplayName("유효하지 않은 리프레시 토큰으로 예외 발생")
-//        void refresh_InvalidRefreshToken() {
-//            // given
-//            String refreshToken = "invalid-refresh-token";
-//            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(false);
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
-//        }
-//
-//        @Test
-//        @DisplayName("리프레시 토큰 타입이 올바르지 않은 경우")
-//        void refresh_InvalidTokenType() {
-//            // given
-//            String refreshToken = "valid-refresh-token";
-//            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
-//            when(jwtTokenProvider.getTokenTypeFromToken(refreshToken)).thenReturn("ACCESS");
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
-//        }
-//
-//        @Test
-//        @DisplayName("유효한 액세스 토큰이 블랙리스트에 추가되는 경우")
-//        void refresh_AccessTokenBlacklisted() {
-//            // given
-//            String refreshToken = "valid-refresh-token";
-//            String accessToken = "valid-access-token";
-//            Long userId = 1L;
-//            User user = mock(User.class);
-//
-//            TokenData tokenData = TokenData.of(refreshToken, "token-family");
-//
-//            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
-//            when(jwtTokenProvider.validateToken(accessToken)).thenReturn(true);
-//            when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
-//            when(userService.findUserById(userId)).thenReturn(user);
-//
-//            setupRefreshMocks(refreshToken, userId, tokenData);
-//
-//            String newAccessToken = "new-access-token";
-//            String newRefreshToken = "new-refresh-token";
-//
-//            when(jwtTokenProvider.generateRefreshToken(eq(user), anyString())).thenReturn(newRefreshToken);
-//            when(jwtTokenProvider.generateToken(eq(user))).thenReturn(newAccessToken);
-//
-//            // when
-//            TokenResponse response = authService.refresh(refreshToken, accessToken);
-//
-//            // then
-//            verify(tokenService).addToBlackList(accessToken);
-//        }
-//
-//    }
-//
-//    private void setupRefreshMocks(String refreshToken, Long userId, TokenData tokenData) {
-//        when(jwtTokenProvider.getTokenTypeFromToken(refreshToken)).thenReturn("REFRESH");
-//        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
-//        when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
-//        when(jwtTokenProvider.getTokenFamilyFromToken(refreshToken)).thenReturn("token-family");
-//        when(tokenService.getRefreshToken(userId)).thenReturn(tokenData);
-//    }
-//
-//}
+package com.mindmate.mindmate_server.auth.service;
+
+import com.mindmate.mindmate_server.auth.dto.*;
+import com.mindmate.mindmate_server.auth.util.JwtTokenProvider;
+import com.mindmate.mindmate_server.auth.util.PasswordValidator;
+import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.user.domain.Profile;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static com.mindmate.mindmate_server.auth.service.AuthServiceImpl.RESEND_LIMIT_MINUTES;
+import static com.mindmate.mindmate_server.auth.service.LoginAttemptService.MAX_ATTEMPTS;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+    @Mock private UserService userService;
+    @Mock private TokenService tokenService;
+    @Mock private EmailService emailService;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private LoginAttemptService loginAttemptService;
+    @Mock private PasswordValidator passwordValidator;
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+    @Mock private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Nested
+    @DisplayName("회원가입 테스트")
+    class RegisterUserTest {
+
+        @Test
+        @DisplayName("정상적인 회원가입 성공")
+        void registerUser_Success() {
+            // given
+            SignUpRequest request = new SignUpRequest("test@email.com", "password123", "password123", true);
+            when(userService.existsByEmail(anyString())).thenReturn(false);
+            when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+
+            // when
+            authService.registerUser(request);
+
+            // then
+            verify(userService).existsByEmail(request.getEmail());
+            verify(passwordValidator).validatePassword(request.getPassword());
+            verify(userService).save(any(User.class));
+            verify(emailService).sendVerificationEmail(any(User.class), anyString());
+        }
+
+        @Test
+        @DisplayName("중복 이메일")
+        void registerUser_DuplicateEmail() {
+            // given
+            SignUpRequest request = new SignUpRequest("test@email.com", "password123", "password123", true);
+            when(userService.existsByEmail(anyString())).thenReturn(true);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.registerUser(request));
+            verify(userService).existsByEmail(request.getEmail());
+        }
+
+        @Test
+        @DisplayName("비밀번호 검증 실패")
+        void registerUser_PasswordMismatch() {
+            // given
+            SignUpRequest request = new SignUpRequest("test@email.com", "password123", "password456", true);
+            doThrow(new CustomException(AuthErrorCode.PASSWORD_MISMATCH))
+                    .when(passwordValidator)
+                    .validatePasswordMatch(request.getPassword(), request.getConfirmPassword());
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.registerUser(request));
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일 재전송")
+    class ResendVerificationEmail {
+        @Test
+        @DisplayName("정상 재전송")
+        void resendVerificationEmail_Success() {
+            // given
+            String email = "test@email.com";
+            String verificationToken = "test-token";
+            User user = mock(User.class);
+
+            when(userService.findByEmail(email)).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(false);
+            when(user.getVerificationToken()).thenReturn(verificationToken);
+            when(valueOperations.get(anyString())).thenReturn(null);
+
+            // when
+            authService.resendVerificationEmail(email);
+
+            // then
+            verify(user).getVerificationToken();
+//            verify(userService).save(user);
+            verify(emailService).sendVerificationEmail(eq(user), eq(verificationToken));
+        }
+
+        @Test
+        @DisplayName("이미 인증된 이메일")
+        void resendVerificationEmail_AlreadyVerified() {
+            // given
+            String email = "test@email.com";
+            User user = mock(User.class);
+
+            when(userService.findByEmail(email)).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(true);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.resendVerificationEmail(email));
+        }
+
+        @Test
+        @DisplayName("재전송 제한 시간")
+        void resendVerificationEmail_TooFrequent() {
+            // given
+            String email = "test@email.com";
+            User user = mock(User.class);
+
+            when(userService.findByEmail(email)).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(false);
+            when(valueOperations.get(anyString()))
+                    .thenReturn(LocalDateTime.now().toString());
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.resendVerificationEmail(email));
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일 인증 테스트")
+    class VerifyEmailTest {
+        @Test
+        @DisplayName("정상적인 이메일 인증 성공")
+        void verifyEmail_Success() {
+            // given
+            String token = "valid-token";
+            User user = mock(User.class);
+
+            when(userService.findVerificationToken(token)).thenReturn(user);
+            when(user.getVerificationToken()).thenReturn(token);
+            when(user.isTokenExpired()).thenReturn(false);
+
+            // when
+            authService.verifyEmail(token);
+
+            // then
+            verify(userService).findVerificationToken(token);
+            verify(user).verifyEmail();
+            verify(user).updateRole(RoleType.ROLE_USER);
+//            verify(userService).save(user); 영속성
+        }
+
+        @Test
+        @DisplayName("잘못된 토큰으로 인증 시도")
+        void verifyEmail_InvalidToken() {
+            // given
+            String token = "invalid-token";
+            when(userService.findVerificationToken(token)).thenReturn(null);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.verifyEmail(token));
+        }
+
+        @Test
+        @DisplayName("만료된 토큰으로 인증 시도")
+        void verifyEmail_ExpiredToken() {
+            // given
+            String token = "expired-token";
+            User user = mock(User.class);
+
+            when(userService.findVerificationToken(token)).thenReturn(user);
+            when(user.getVerificationToken()).thenReturn(token);
+            when(user.isTokenExpired()).thenReturn(true);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.verifyEmail(token));
+        }
+
+        @Test
+        @DisplayName("재전송 제한 시간 초과하지 않은 경우")
+        void resendVerificationEmail_TooFrequent() {
+            // given
+            String email = "test@email.com";
+            User user = mock(User.class);
+
+            LocalDateTime recentRequestTime = LocalDateTime.now().minusMinutes(RESEND_LIMIT_MINUTES - 1);
+            when(userService.findByEmail(email)).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(false);
+
+            when(valueOperations.get(anyString())).thenReturn(recentRequestTime.toString());
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.resendVerificationEmail(email));
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인")
+    class Login {
+        @Test
+        @DisplayName("정상 로그인")
+        void login_Success() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "password123");
+            User user = mock(User.class);
+
+            Profile profile = mock(Profile.class);
+            when(user.getProfile()).thenReturn(profile);
+
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
+            when(userService.findByEmail(request.getEmail())).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(true);
+            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(true);
+
+            String accessToken = "access-token";
+            String refreshToken = "refresh-token";
+
+            when(jwtTokenProvider.generateToken(any(User.class))).thenReturn(accessToken);
+            when(jwtTokenProvider.generateRefreshToken(any(User.class), anyString())).thenReturn(refreshToken);
+
+            // when
+            LoginResponse response = authService.login(request);
+
+            // then
+            assertNotNull(response);
+            assertEquals(accessToken, response.getAccessToken());
+            assertEquals(refreshToken, response.getRefreshToken());
+
+            verify(loginAttemptService).loginSucceeded(request.getEmail());
+        }
+
+        @Test
+        @DisplayName("계정 잠금 상태에서 로그인 시도")
+        void login_AccountLocked() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "password123");
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(true);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.login(request));
+        }
+
+        @Test
+        @DisplayName("이메일 미인증 상태에서 로그인 시도")
+        void login_EmailNotVerified() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "password123");
+            User user = mock(User.class);
+
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
+            when(userService.findByEmail(request.getEmail())).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(false);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.login(request));
+        }
+
+        @Test
+        @DisplayName("비밀번호 불일치 로그인 실패")
+        void login_PasswordMismatch() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "wrong-password");
+            User user = mock(User.class);
+
+            Profile profile = mock(Profile.class);
+            when(user.getProfile()).thenReturn(profile);
+
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
+            when(userService.findByEmail(request.getEmail())).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(true);
+            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(false);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.login(request));
+            verify(loginAttemptService).loginFailed(request.getEmail());
+        }
+
+        @Test
+        @DisplayName("프로필 작성이 필요한 경우 예외 발생")
+        void login_ProfileNotRegistered() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "password123");
+            User user = mock(User.class);
+
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
+            when(userService.findByEmail(request.getEmail())).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(true);
+            when(user.getProfile()).thenReturn(null); // 프로필이 없음을 명시
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> authService.login(request));
+            assertEquals(AuthErrorCode.PROFILE_NOT_REGISTER, exception.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("로그인 시도가 횟수 남지 않아 계정이 잠긴 경우")
+        void login_AccountLockedAfterMaxAttempts() {
+            // given
+            LoginRequest request = new LoginRequest("test@email.com", "wrong-password");
+            User user = mock(User.class);
+
+            Profile profile = mock(Profile.class);
+            when(user.getProfile()).thenReturn(profile);
+
+            when(loginAttemptService.isBlocked(request.getEmail())).thenReturn(false);
+            when(userService.findByEmail(request.getEmail())).thenReturn(user);
+            when(user.isEmailVerified()).thenReturn(true);
+            when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(false);
+            when(loginAttemptService.getCurrentAttempts(request.getEmail())).thenReturn(MAX_ATTEMPTS);
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> authService.login(request));
+
+            assertEquals(AuthErrorCode.ACCOUNT_LOCKED, exception.getErrorCode());;
+            Map<String, Object> details = (Map<String, Object>) exception.getDetails();
+            assertNotNull(details);
+            assertEquals(0, details.get("remainingAttempts"));
+
+            verify(loginAttemptService).loginFailed(request.getEmail());
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃 테스트")
+    class LogoutTest {
+        @Test
+        @DisplayName("정상적인 로그아웃 성공")
+        void logout_Success() {
+            // given
+            String token = "valid-access-token";
+            Long userId = 1L;
+
+            when(jwtTokenProvider.getUserIdFromToken(token)).thenReturn(userId);
+
+            // when
+            authService.logout(token);
+
+            // then
+            verify(tokenService).addToBlackList(token);
+            verify(tokenService).invalidateRefreshToken(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 갱신 테스트")
+    class RefreshTest {
+        @Test
+        @DisplayName("정상적인 토큰 갱신 성공")
+        void refresh_Success() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            String accessToken = "old-access-token";
+
+            Long userId = 1L;
+            User user = mock(User.class);
+            TokenData tokenData = TokenData.of(refreshToken, "token-family");
+
+            String newAccessToken = "new-access-token";
+            String newRefreshToken = "new-refresh-token";
+
+            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
+            when(jwtTokenProvider.getTokenTypeFromToken(refreshToken)).thenReturn("REFRESH");
+            when(userService.findUserById(userId)).thenReturn(user);
+            when(jwtTokenProvider.getTokenFamilyFromToken(refreshToken)).thenReturn("token-family");
+            when(tokenService.getRefreshToken(userId)).thenReturn(tokenData);
+
+            when(jwtTokenProvider.generateToken(user)).thenReturn(newAccessToken);
+            when(jwtTokenProvider.generateRefreshToken(eq(user), anyString())).thenReturn(newRefreshToken);
+
+            // when
+            TokenResponse response = authService.refresh(refreshToken, accessToken);
+
+            // then
+            assertNotNull(response);
+            assertEquals(newAccessToken, response.getAccessToken());
+            assertEquals(newRefreshToken, response.getRefreshToken());
+
+            verify(tokenService).addToBlackList(refreshToken);
+            verify(tokenService).saveRefreshToken(eq(userId), eq(newRefreshToken), anyString());
+        }
+
+        @Test
+        @DisplayName("리프레시 토큰 재사용 감지")
+        void refresh_TokenReuseDetected() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            Long userId = 1L;
+
+//            TokenData tokenData = null;
+
+            setupRefreshMocks(refreshToken, userId, null);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
+            verify(tokenService).invalidateRefreshToken(userId);
+        }
+
+        @Test
+        @DisplayName("저장된 토큰 데이터가 null인 경우 예외 발생")
+        void refresh_StoredTokenDataNull() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            Long userId = 1L;
+
+            setupRefreshMocks(refreshToken, userId, null);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
+        }
+
+        @Test
+        @DisplayName("토큰 패밀리가 일치하지 않는 경우 예외 발생")
+        void refresh_TokenFamilyMismatch() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            Long userId = 1L;
+            TokenData tokenData = TokenData.of("refresh-token", "different-family");
+
+            setupRefreshMocks(refreshToken, userId, tokenData);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 리프레시 토큰으로 예외 발생")
+        void refresh_InvalidRefreshToken() {
+            // given
+            String refreshToken = "invalid-refresh-token";
+            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(false);
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
+        }
+
+        @Test
+        @DisplayName("리프레시 토큰 타입이 올바르지 않은 경우")
+        void refresh_InvalidTokenType() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(jwtTokenProvider.getTokenTypeFromToken(refreshToken)).thenReturn("ACCESS");
+
+            // when & then
+            assertThrows(CustomException.class, () -> authService.refresh(refreshToken, null));
+        }
+
+        @Test
+        @DisplayName("유효한 액세스 토큰이 블랙리스트에 추가되는 경우")
+        void refresh_AccessTokenBlacklisted() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            String accessToken = "valid-access-token";
+            Long userId = 1L;
+            User user = mock(User.class);
+
+            TokenData tokenData = TokenData.of(refreshToken, "token-family");
+
+            when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(jwtTokenProvider.validateToken(accessToken)).thenReturn(true);
+            when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
+            when(userService.findUserById(userId)).thenReturn(user);
+
+            setupRefreshMocks(refreshToken, userId, tokenData);
+
+            String newAccessToken = "new-access-token";
+            String newRefreshToken = "new-refresh-token";
+
+            when(jwtTokenProvider.generateRefreshToken(eq(user), anyString())).thenReturn(newRefreshToken);
+            when(jwtTokenProvider.generateToken(eq(user))).thenReturn(newAccessToken);
+
+            // when
+            TokenResponse response = authService.refresh(refreshToken, accessToken);
+
+            // then
+            verify(tokenService).addToBlackList(accessToken);
+        }
+
+    }
+
+    private void setupRefreshMocks(String refreshToken, Long userId, TokenData tokenData) {
+        when(jwtTokenProvider.getTokenTypeFromToken(refreshToken)).thenReturn("REFRESH");
+        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUserIdFromToken(refreshToken)).thenReturn(userId);
+        when(jwtTokenProvider.getTokenFamilyFromToken(refreshToken)).thenReturn("token-family");
+        when(tokenService.getRefreshToken(userId)).thenReturn(tokenData);
+    }
+
+}

--- a/src/test/java/com/mindmate/mindmate_server/auth/service/EmailServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/service/EmailServiceTest.java
@@ -1,73 +1,73 @@
-//package com.mindmate.mindmate_server.auth.service;
-//
-//import com.mindmate.mindmate_server.global.exception.CustomException;
-//import com.mindmate.mindmate_server.user.domain.User;
-//import jakarta.mail.MessagingException;
-//import jakarta.mail.internet.MimeMessage;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.mail.javamail.JavaMailSender;
-//import org.springframework.mail.javamail.MimeMessageHelper;
-//
-//import static org.junit.jupiter.api.Assertions.assertThrows;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//class EmailServiceTest {
-//    @Mock private JavaMailSender mailSender;
-//    @Mock private MimeMessage mimeMessage;
-//    @Mock private MimeMessageHelper mimeMessageHelper;
-//
-//    @InjectMocks
-//    private EmailService emailService;
-//
-//    @Nested
-//    @DisplayName("이메일 전송")
-//    class EmailSendTest {
-//        @Test
-//        @DisplayName("이메일 전송 성공")
-//        void sendVerificationEmail_Success() throws MessagingException {
-//            // given
-//            User user = User.builder()
-//                    .email("test@example.com")
-//                    .build();
-//            String token = "test-token";
-//
-//            when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
-//            doNothing().when(mailSender).send(any(MimeMessage.class));
-//
-//            // when
-//            emailService.sendVerificationEmail(user, token);
-//
-//            // then
-//            verify(mailSender).createMimeMessage();
-//            verify(mailSender).send(any(MimeMessage.class));
-//        }
-//
-//        @Test
-//        @DisplayName("이메일 전송 실패")
-//        void sendVerificationEmail_Failed() throws MessagingException {
-//            // given
-//            User user = User.builder()
-//                    .email("test@example.com")
-//                    .build();
-//            String token = "test-token";
-//
-//            when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
-//            doAnswer(invocation -> {
-//                throw new MessagingException("Failed to send email");
-//            }).when(mailSender).send(any(MimeMessage.class));
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> emailService.sendVerificationEmail(user, token));
-//            verify(mailSender).createMimeMessage();
-//            verify(mailSender).send(any(MimeMessage.class));
-//        }
-//    }
-//}
+package com.mindmate.mindmate_server.auth.service;
+
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.user.domain.User;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+    @Mock private JavaMailSender mailSender;
+    @Mock private MimeMessage mimeMessage;
+    @Mock private MimeMessageHelper mimeMessageHelper;
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Nested
+    @DisplayName("이메일 전송")
+    class EmailSendTest {
+        @Test
+        @DisplayName("이메일 전송 성공")
+        void sendVerificationEmail_Success() throws MessagingException {
+            // given
+            User user = User.builder()
+                    .email("test@example.com")
+                    .build();
+            String token = "test-token";
+
+            when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+            doNothing().when(mailSender).send(any(MimeMessage.class));
+
+            // when
+            emailService.sendVerificationEmail(user, token);
+
+            // then
+            verify(mailSender).createMimeMessage();
+            verify(mailSender).send(any(MimeMessage.class));
+        }
+
+        @Test
+        @DisplayName("이메일 전송 실패")
+        void sendVerificationEmail_Failed() throws MessagingException {
+            // given
+            User user = User.builder()
+                    .email("test@example.com")
+                    .build();
+            String token = "test-token";
+
+            when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+            doAnswer(invocation -> {
+                throw new MessagingException("Failed to send email");
+            }).when(mailSender).send(any(MimeMessage.class));
+
+            // when & then
+            assertThrows(CustomException.class, () -> emailService.sendVerificationEmail(user, token));
+            verify(mailSender).createMimeMessage();
+            verify(mailSender).send(any(MimeMessage.class));
+        }
+    }
+}

--- a/src/test/java/com/mindmate/mindmate_server/auth/service/LoginAttemptServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/service/LoginAttemptServiceTest.java
@@ -1,136 +1,137 @@
-//package com.mindmate.mindmate_server.auth.service;
-//
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.redis.core.RedisTemplate;
-//import org.springframework.data.redis.core.ValueOperations;
-//
-//import java.util.concurrent.TimeUnit;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//class LoginAttemptServiceTest {
-//    @Mock private RedisTemplate<String, String> redisTemplate;
-//    @Mock private ValueOperations<String, String> valueOperations;
-//
-//    @InjectMocks
-//    private LoginAttemptService loginAttemptService;
-//
-//    @BeforeEach
-//    void setup() {
-//        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-//    }
-//
-//    @Nested
-//    @DisplayName("로그인 실패 처리 테스트")
-//    class LoginFailedTest {
+package com.mindmate.mindmate_server.auth.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoginAttemptServiceTest {
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private LoginAttemptService loginAttemptService;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Nested
+    @DisplayName("로그인 실패 처리 테스트")
+    class LoginFailedTest {
+        @Test
+        @DisplayName("첫 로그인 실패")
+        void loginFailed_FirstAttempt() {
+            // given
+            String email = "test@example.com";
+            when(valueOperations.get("login-attempts:" + email)).thenReturn(null);
+
+            // when
+            loginAttemptService.loginFailed(email);
+
+            // then
+            verify(valueOperations).set(
+                    eq("login-attempts:" + email),
+                    eq("1"),
+                    eq(30L),
+                    eq(TimeUnit.MINUTES)
+            );
+        }
+
 //        @Test
-//        @DisplayName("첫 로그인 실패")
-//        void loginFailed_FirstAttempt() {
-//            // given
-//            String email = "test@example.com";
-//            when(valueOperations.get("login-attempts:" + email)).thenReturn(null);
-//
-//            // when
-//            loginAttemptService.loginFailed(email);
-//
-//            // then
-//            verify(valueOperations).set(
-//                    eq("login-attempts:" + email),
-//                    eq("1"),
-//                    eq(30L),
-//                    eq(TimeUnit.MINUTES)
-//            );
-//        }
-//
-////        @Test
-////        @DisplayName("반복되는 로그인 실패")
-//
-//        @Test
-//        @DisplayName("최대 시도 횟수 초과")
-//        void loginFailed_ExceedMaxAttempts() {
-//            // given
-//            String email = "test@example.com";
-//            when(valueOperations.get("login-attempts:" + email)).thenReturn("4");
-//
-//            // when
-//            loginAttemptService.loginFailed(email);
-//
-//            // then
-//            verify(valueOperations).set(
-//                    eq("login-locked:" + email),
-//                    eq("LOCKED"),
-//                    eq(30L),
-//                    eq(TimeUnit.MINUTES)
-//            );
-//        }
-//    }
-//
-//    @Test
-//    @DisplayName("로그인 성공 시 시도 횟수 초기화")
-//    void loginSucceeded() {
-//        // given
-//        String email = "test@example.com";
-//
-//        // when
-//        loginAttemptService.loginSucceeded(email);
-//
-//        // then
-//        verify(redisTemplate).delete("login-attempts:" + email);
-//        verify(redisTemplate).delete("login-locked:" + email);
-//    }
-//
-//    @Test
-//    @DisplayName("계정 잠금 상태 확인")
-//    void isBlocked() {
-//        // given
-//        String email = "test@exmaple.com";
-//        when(redisTemplate.hasKey("login-locked:" + email)).thenReturn(true);
-//
-//        // when
-//        boolean result = loginAttemptService.isBlocked(email);
-//
-//        // then
-//        assertTrue(result);
-//    }
-//
-//    @Test
-//    @DisplayName("현재 로그인 시도 횟수")
-//    void getCurrentAttempts() {
-//        // given
-//        String email = "test@example.com";
-//        when(valueOperations.get("login-attempts:" + email)).thenReturn("3");
-//
-//        // when
-//        int attempts = loginAttemptService.getCurrentAttempts(email);
-//
-//        // then
-//        assertEquals(3, attempts);
-//    }
-//
-//    @Test
-//    @DisplayName("계정 잠금 남은 시간 확인")
-//    void getRemainingLockTime() {
-//        // given
-//        String email = "test@example.com";
-//        when(redisTemplate.getExpire("login-locked:" + email, TimeUnit.MINUTES)).thenReturn(15L);
-//
-//        // when
-//        Long remainingTime = loginAttemptService.getRemainingLockTime(email);
-//
-//        // then
-//        assertEquals(15L, remainingTime);
-//    }
-//
-//
-//
-//}
+//        @DisplayName("반복되는 로그인 실패")
+
+        @Test
+        @DisplayName("최대 시도 횟수 초과")
+        void loginFailed_ExceedMaxAttempts() {
+            // given
+            String email = "test@example.com";
+            when(valueOperations.get("login-attempts:" + email)).thenReturn("4");
+
+            // when
+            loginAttemptService.loginFailed(email);
+
+            // then
+            verify(valueOperations).set(
+                    eq("login-locked:" + email),
+                    eq("LOCKED"),
+                    eq(30L),
+                    eq(TimeUnit.MINUTES)
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 시도 횟수 초기화")
+    void loginSucceeded() {
+        // given
+        String email = "test@example.com";
+
+        // when
+        loginAttemptService.loginSucceeded(email);
+
+        // then
+        verify(redisTemplate).delete("login-attempts:" + email);
+        verify(redisTemplate).delete("login-locked:" + email);
+    }
+
+    @Test
+    @DisplayName("계정 잠금 상태 확인")
+    void isBlocked() {
+        // given
+        String email = "test@exmaple.com";
+        when(redisTemplate.hasKey("login-locked:" + email)).thenReturn(true);
+
+        // when
+        boolean result = loginAttemptService.isBlocked(email);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("현재 로그인 시도 횟수")
+    void getCurrentAttempts() {
+        // given
+        String email = "test@example.com";
+        when(valueOperations.get("login-attempts:" + email)).thenReturn("3");
+
+        // when
+        int attempts = loginAttemptService.getCurrentAttempts(email);
+
+        // then
+        assertEquals(3, attempts);
+    }
+
+    @Test
+    @DisplayName("계정 잠금 남은 시간 확인")
+    void getRemainingLockTime() {
+        // given
+        String email = "test@example.com";
+        when(redisTemplate.getExpire("login-locked:" + email, TimeUnit.MINUTES)).thenReturn(15L);
+
+        // when
+        Long remainingTime = loginAttemptService.getRemainingLockTime(email);
+
+        // then
+        assertEquals(15L, remainingTime);
+    }
+
+
+
+}

--- a/src/test/java/com/mindmate/mindmate_server/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/auth/service/TokenServiceTest.java
@@ -1,215 +1,217 @@
-//package com.mindmate.mindmate_server.auth.service;
-//
-//import com.fasterxml.jackson.core.JsonProcessingException;
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.mindmate.mindmate_server.auth.dto.TokenData;
-//import com.mindmate.mindmate_server.auth.service.TokenService;
-//import com.mindmate.mindmate_server.auth.util.JwtTokenProvider;
-//import com.mindmate.mindmate_server.global.exception.CustomException;
-//import org.junit.jupiter.api.*;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.redis.core.RedisTemplate;
-//import org.springframework.data.redis.core.ValueOperations;
-//import org.springframework.test.util.ReflectionTestUtils;
-//
-//import java.util.concurrent.TimeUnit;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//class TokenServiceTest {
-//    @Mock private RedisTemplate<String, String> redisTemplate;
-//    @Mock private JwtTokenProvider jwtTokenProvider;
-//    @Mock private ObjectMapper objectMapper;
-//    @Mock private ValueOperations<String, String> valueOperations;
-//
-//    @InjectMocks
-//    private TokenService tokenService;
-//
-//    @BeforeEach
-//    void setup() {
-//        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-//    }
-//
-//    @Nested
-//    @DisplayName("리프레시 토큰 저장 테스트")
-//    class SaveRefreshTokenTest {
-//        @Test
-//        @DisplayName("리프레시 토큰 저장 성공")
-//        void saveRefreshToken_Success() throws JsonProcessingException {
-//            // given
-//            Long userId = 1L;
-//            String refreshToken = "refresh-token";
-//            String tokenFamily = "token-family";
-//            String tokenDataJson = "token-data-json";
-//
-//            lenient().when(objectMapper.writeValueAsString(any(TokenData.class))).thenReturn(tokenDataJson);
-//
-//            // when
-//            tokenService.saveRefreshToken(userId, refreshToken, tokenFamily);
-//
-//            // then
-//            verify(valueOperations).set(
-//                    eq("RT:" + userId),
-//                    eq(tokenDataJson),
-//                    eq(7L),
-//                    eq(TimeUnit.DAYS)
-//            );
-//        }
-//
-//        @Test
-//        @DisplayName("JSON 처리 실패시 예외 발생")
-//        void saveRefreshToken_JsonProcessingException() throws JsonProcessingException {
-//            // given
-//            lenient().when(objectMapper.writeValueAsString(any(TokenData.class)))
-//                    .thenThrow(new JsonProcessingException("Error"){});
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> tokenService.saveRefreshToken(1L, "token", "family"));
-//        }
-//    }
-//    @Nested
-//    @DisplayName("리프레시 토큰 조회 테스트")
-//    class GetRefreshTokenTest {
-//        @Test
-//        @DisplayName("리프레시 토큰 조회 성공")
-//        void getRefreshToken_Success() throws JsonProcessingException {
-//            // given
-//            Long userId = 1L;
-//            String tokenDataJson = "token-data-json";
-//            TokenData expectedTokenData = TokenData.of("token", "family");
-//
-//            when(valueOperations.get("RT:" + userId)).thenReturn(tokenDataJson);
-//            when(objectMapper.readValue(eq(tokenDataJson), eq(TokenData.class))).thenReturn(expectedTokenData);
-//
-//            // when
-//            TokenData result = tokenService.getRefreshToken(userId);
-//
-//            // then
-//            assertNotNull(result);
-//            assertEquals(expectedTokenData, result);
-//        }
-//
-//        @Test
-//        @DisplayName("저장된 토큰이 없을 경우 null 반환")
-//        void getRefreshToken_NotFound() {
-//            // given
-//            when(valueOperations.get(anyString())).thenReturn(null);
-//
-//            // when
-//            TokenData result = tokenService.getRefreshToken(1L);
-//
-//            // then
-//            assertNull(result);
-//        }
-//
-//        @Test
-//        @DisplayName("저장된 토큰 조회 시 JSON 처리 실패")
-//        void getRefreshToken_JsonProcessingException() throws JsonProcessingException{
-//            // given
-//            Long userId = 1L;
-//            String tokenDataJson = "invalid-json";
-//            when(valueOperations.get("RT:" + userId)).thenReturn(tokenDataJson);
-//            when(objectMapper.readValue(eq(tokenDataJson), eq(TokenData.class)))
-//                    .thenThrow(new JsonProcessingException("Error"){});
-//
-//            // when & then
-//            assertThrows(CustomException.class, () -> tokenService.getRefreshToken(userId));
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("블랙리스트 관련 테스트")
-//    class BlacklistTest {
-//        @Test
-//        @DisplayName("토큰 블랙리스트 추가 성공")
-//        void addToBlacklist_Success() {
-//            // given
-//            String token = "test-token";
-//            long expiration = 3600000L;
-//
-//            when(jwtTokenProvider.getExpirationFromToken(token)).thenReturn(expiration);
-//
-//            // when
-//            tokenService.addToBlackList(token);
-//
-//            // then
-//            verify(valueOperations).set(
-//                    eq("BL:" + token),
-//                    eq("blacklisted"),
-//                    eq(expiration),
-//                    eq(TimeUnit.MILLISECONDS)
-//            );
-//        }
-//
-//        @Test
-//        @DisplayName("토큰 블랙리스트 확인")
-//        void isTokenBlacklisted_Success() {
-//            // given
-//            String token = "test-token";
-//            when(redisTemplate.hasKey("BL:" + token)).thenReturn(true);
-//
-//            // when
-//            boolean result = tokenService.isTokenBlacklisted(token);
-//
-//            // then
-//            assertTrue(result);
-//            verify(redisTemplate).hasKey("BL:" + token);
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("토큰 무효화 테스트")
-//    class InvalidateTokenTest {
-//        @Test
-//        @DisplayName("리프레시 토큰 무효화 성공")
-//        void invalidateRefreshToken_Success() {
-//            // given
-//            Long userId = 1L;
-//
-//            // when
-//            tokenService.invalidateRefreshToken(userId);
-//
-//            // then
-//            verify(redisTemplate).delete("RT:" + userId);
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("토큰 마스킹 테스트")
-//    class MaskTokenTest {
-//        @Test
-//        @DisplayName("긴 토큰 마스킹 처리")
-//        void maskToken_LongToken() {
-//            // given
-//            String token = "abcdefghijklmnopqrstuvwxyz";
-//            String expectedMask = "abcde****************vwxyz";
-//
-//            // when
-//            String result = ReflectionTestUtils.invokeMethod(tokenService, "maskToken", token);
-//
-//            // then
-//            assertEquals(expectedMask, result);
-//        }
-//
-//        @Test
-//        @DisplayName("짧은 토큰 마스킹 처리")
-//        void maskToken_ShortToken() {
-//            // given
-//            String token = "abcde";
-//            String expectedMask = "*****";
-//
-//            // when
-//            String result = ReflectionTestUtils.invokeMethod(tokenService, "maskToken", token);
-//
-//            // then
-//            assertEquals(expectedMask, result);
-//        }
-//
-//    }
-//
-//}
+package com.mindmate.mindmate_server.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mindmate.mindmate_server.auth.dto.TokenData;
+import com.mindmate.mindmate_server.auth.util.JwtTokenProvider;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private ObjectMapper objectMapper;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Nested
+    @DisplayName("리프레시 토큰 저장 테스트")
+    class SaveRefreshTokenTest {
+        @Test
+        @DisplayName("리프레시 토큰 저장 성공")
+        void saveRefreshToken_Success() throws JsonProcessingException {
+            // given
+            Long userId = 1L;
+            String refreshToken = "refresh-token";
+            String tokenFamily = "token-family";
+            String tokenDataJson = "token-data-json";
+
+            lenient().when(objectMapper.writeValueAsString(any(TokenData.class))).thenReturn(tokenDataJson);
+
+            // when
+            tokenService.saveRefreshToken(userId, refreshToken, tokenFamily);
+
+            // then
+            verify(valueOperations).set(
+                    eq("RT:" + userId),
+                    eq(tokenDataJson),
+                    eq(7L),
+                    eq(TimeUnit.DAYS)
+            );
+        }
+
+        @Test
+        @DisplayName("JSON 처리 실패시 예외 발생")
+        void saveRefreshToken_JsonProcessingException() throws JsonProcessingException {
+            // given
+            lenient().when(objectMapper.writeValueAsString(any(TokenData.class)))
+                    .thenThrow(new JsonProcessingException("Error"){});
+
+            // when & then
+            assertThrows(CustomException.class, () -> tokenService.saveRefreshToken(1L, "token", "family"));
+        }
+    }
+    @Nested
+    @DisplayName("리프레시 토큰 조회 테스트")
+    class GetRefreshTokenTest {
+        @Test
+        @DisplayName("리프레시 토큰 조회 성공")
+        void getRefreshToken_Success() throws JsonProcessingException {
+            // given
+            Long userId = 1L;
+            String tokenDataJson = "token-data-json";
+            TokenData expectedTokenData = TokenData.of("token", "family");
+
+            when(valueOperations.get("RT:" + userId)).thenReturn(tokenDataJson);
+            when(objectMapper.readValue(eq(tokenDataJson), eq(TokenData.class))).thenReturn(expectedTokenData);
+
+            // when
+            TokenData result = tokenService.getRefreshToken(userId);
+
+            // then
+            assertNotNull(result);
+            assertEquals(expectedTokenData, result);
+        }
+
+        @Test
+        @DisplayName("저장된 토큰이 없을 경우 null 반환")
+        void getRefreshToken_NotFound() {
+            // given
+            when(valueOperations.get(anyString())).thenReturn(null);
+
+            // when
+            TokenData result = tokenService.getRefreshToken(1L);
+
+            // then
+            assertNull(result);
+        }
+
+        @Test
+        @DisplayName("저장된 토큰 조회 시 JSON 처리 실패")
+        void getRefreshToken_JsonProcessingException() throws JsonProcessingException{
+            // given
+            Long userId = 1L;
+            String tokenDataJson = "invalid-json";
+            when(valueOperations.get("RT:" + userId)).thenReturn(tokenDataJson);
+            when(objectMapper.readValue(eq(tokenDataJson), eq(TokenData.class)))
+                    .thenThrow(new JsonProcessingException("Error"){});
+
+            // when & then
+            assertThrows(CustomException.class, () -> tokenService.getRefreshToken(userId));
+        }
+    }
+
+    @Nested
+    @DisplayName("블랙리스트 관련 테스트")
+    class BlacklistTest {
+        @Test
+        @DisplayName("토큰 블랙리스트 추가 성공")
+        void addToBlacklist_Success() {
+            // given
+            String token = "test-token";
+            long expiration = 3600000L;
+
+            when(jwtTokenProvider.getExpirationFromToken(token)).thenReturn(expiration);
+
+            // when
+            tokenService.addToBlackList(token);
+
+            // then
+            verify(valueOperations).set(
+                    eq("BL:" + token),
+                    eq("blacklisted"),
+                    eq(expiration),
+                    eq(TimeUnit.MILLISECONDS)
+            );
+        }
+
+        @Test
+        @DisplayName("토큰 블랙리스트 확인")
+        void isTokenBlacklisted_Success() {
+            // given
+            String token = "test-token";
+            when(redisTemplate.hasKey("BL:" + token)).thenReturn(true);
+
+            // when
+            boolean result = tokenService.isTokenBlacklisted(token);
+
+            // then
+            assertTrue(result);
+            verify(redisTemplate).hasKey("BL:" + token);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 무효화 테스트")
+    class InvalidateTokenTest {
+        @Test
+        @DisplayName("리프레시 토큰 무효화 성공")
+        void invalidateRefreshToken_Success() {
+            // given
+            Long userId = 1L;
+
+            // when
+            tokenService.invalidateRefreshToken(userId);
+
+            // then
+            verify(redisTemplate).delete("RT:" + userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 마스킹 테스트")
+    class MaskTokenTest {
+        @Test
+        @DisplayName("긴 토큰 마스킹 처리")
+        void maskToken_LongToken() {
+            // given
+            String token = "abcdefghijklmnopqrstuvwxyz";
+            String expectedMask = "abcde****************vwxyz";
+
+            // when
+            String result = ReflectionTestUtils.invokeMethod(tokenService, "maskToken", token);
+
+            // then
+            assertEquals(expectedMask, result);
+        }
+
+        @Test
+        @DisplayName("짧은 토큰 마스킹 처리")
+        void maskToken_ShortToken() {
+            // given
+            String token = "abcde";
+            String expectedMask = "*****";
+
+            // when
+            String result = ReflectionTestUtils.invokeMethod(tokenService, "maskToken", token);
+
+            // then
+            assertEquals(expectedMask, result);
+        }
+
+    }
+
+}

--- a/src/test/java/com/mindmate/mindmate_server/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/profile/service/ProfileServiceTest.java
@@ -56,7 +56,7 @@ class ProfileServiceTest {
                 .profileImage("http://example.com/image.jpg")
                 .nickname("ajou")
                 .department("소프트웨어학과")
-                .entranceTime(LocalDateTime.now().minusYears(2))
+                .entranceTime(2020)
                 .graduation(false)
                 .build();
 
@@ -197,7 +197,7 @@ class ProfileServiceTest {
                 .profileImage("http://example.com/new_image.jpg")
                 .nickname("ajou")
                 .department("소프트웨어학과")
-                .entranceTime(LocalDateTime.now().minusYears(2))
+                .entranceTime(2020)
                 .graduation(false)
                 .build();
 
@@ -268,7 +268,7 @@ class ProfileServiceTest {
                 .profileImage("http://example.com/updated_image.jpg")
                 .nickname("new ajou")
                 .department("심리학과")
-                .entranceTime(LocalDateTime.now().minusYears(5))
+                .entranceTime(2020)
                 .graduation(true)
                 .build();
 

--- a/src/test/java/com/mindmate/mindmate_server/user/service/UserServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/user/service/UserServiceTest.java
@@ -1,171 +1,193 @@
-//package com.mindmate.mindmate_server.user.service;
-//
-//import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
-//import com.mindmate.mindmate_server.global.exception.CustomException;
-//import com.mindmate.mindmate_server.global.exception.UserErrorCode;
-//import com.mindmate.mindmate_server.user.domain.RoleType;
-//import com.mindmate.mindmate_server.user.domain.User;
-//import com.mindmate.mindmate_server.user.repository.UserRepository;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//import java.util.Optional;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//@ExtendWith(MockitoExtension.class)
-//class UserServiceTest {
-//    @Mock private UserRepository userRepository;
-//
-//    @InjectMocks
-//    private UserServiceImpl userService;
-//
-//    @Nested
-//    @DisplayName("사용자 조회 테스트")
-//    class FindUserTest {
-//        @Test
-//        @DisplayName("ID로 사용자 조회 성공")
-//        void findUserById_Success() {
-//            // given
-//            Long userId = 1L;
-//            User expectedUser = createUser();
-//
-//            when(userRepository.findById(userId)).thenReturn(Optional.of(expectedUser));
-//
-//            // when
-//            User foundUser = userService.findUserById(userId);
-//
-//            // then
-//            assertNotNull(foundUser);
-//            assertEquals(expectedUser.getEmail(), foundUser.getEmail());
-//            verify(userRepository).findById(userId);
-//        }
-//
-//        @Test
-//        @DisplayName("존재하지 않는 ID로 조회 시 예외 발생")
-//        void findUserById_UserNotFound() {
-//            // given
-//            Long userId = 999L;
-//
-//            when(userRepository.findById(userId)).thenReturn(Optional.empty());
-//
-//            // when & then
-//            CustomException exception = assertThrows(CustomException.class, () -> userService.findUserById(userId));
-//            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
-//            // then
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("이메일 관련 테스트")
-//    class EmailVerificationTest {
-//        @Test
-//        @DisplayName("이메일로 사용자 조회 성공")
-//        void findByEmail_Success() {
-//            // given
-//            String email = "test@example.com";
-//            User expectedUser = createUser();
-//
-//            when(userRepository.findByEmail(email)).thenReturn(Optional.of(expectedUser));
-//
-//            // when
-//            User foundUser = userService.findByEmail(email);
-//
-//            // then
-//            assertNotNull(foundUser);
-//            assertEquals(email, foundUser.getEmail());
-//            verify(userRepository).findByEmail(email);
-//        }
-//
-//        @Test
-//        @DisplayName("존재하지 않는 이메일로 사용자 조회 실패")
-//        void findByEmail_UserNotFound() {
-//            // given
-//            String email = "nonexist@example.com";
-//            when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
-//
-//            // when & then
-//            CustomException exception = assertThrows(CustomException.class, () -> userService.findByEmail(email));
-//            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
-//        }
-//
-//        @Test
-//        @DisplayName("이메일 존재 여부 확인 - 존재하는 경우")
-//        void existsByEmail_True() {
-//            // given
-//            String email = "test@example.com";
-//            when(userRepository.existsByEmail(email)).thenReturn(true);
-//
-//            // when
-//            boolean exists = userService.existsByEmail(email);
-//
-//            // then
-//            assertTrue(exists);
-//            verify(userRepository).existsByEmail(email);
-//        }
-//
-//        @Test
-//        @DisplayName("토큰으로 사용자 조회 성공")
-//        void findVerificationToken_Success() {
-//            // given
-//            String token = "valid-token";
-//            User expectedUser = createUser();
-//
-//            when(userRepository.findByVerificationToken(token)).thenReturn(Optional.of(expectedUser));
-//
-//            // when
-//            User foundUser = userService.findVerificationToken(token);
-//
-//            // then
-//            assertNotNull(foundUser);
-//            verify(userRepository).findByVerificationToken(token);
-//        }
-//
-//        @Test
-//        @DisplayName("잘못된 토큰으로 조히 시 예외 발생")
-//        void findVerificationToken_InvalidToken() {
-//            // given
-//            String token = "invalid-token";
-//
-//            when(userRepository.findByVerificationToken(token)).thenReturn(Optional.empty());
-//
-//            // when & then
-//            CustomException exception = assertThrows(CustomException.class, () -> userService.findVerificationToken(token));
-//            assertEquals(AuthErrorCode.INVALID_TOKEN, exception.getErrorCode());
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("사용자 저장 테스트")
-//    class SaveUserTest {
-//        @Test
-//        @DisplayName("사용자 저장 성공")
-//        void save_Success() {
-//            // given
-//            User user = createUser();
-//            when(userRepository.save(any(User.class))).thenReturn(user);
-//
-//            // when
-//            userService.save(user);
-//
-//            // then
-//            verify(userRepository).save(user);
-//        }
-//    }
-//
-//    private User createUser() {
-//        return User.builder()
-//                .email("test@example.com")
-//                .password("password")
-//                .role(RoleType.ROLE_USER)
-//                .build();
-//    }
-//}
+package com.mindmate.mindmate_server.user.service;
+
+import com.mindmate.mindmate_server.global.exception.AuthErrorCode;
+import com.mindmate.mindmate_server.global.exception.CustomException;
+import com.mindmate.mindmate_server.global.exception.UserErrorCode;
+import com.mindmate.mindmate_server.user.domain.RoleType;
+import com.mindmate.mindmate_server.user.domain.User;
+import com.mindmate.mindmate_server.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Nested
+    @DisplayName("사용자 조회 테스트")
+    class FindUserTest {
+        @Test
+        @DisplayName("ID로 사용자 조회 성공")
+        void findUserById_Success() {
+            // given
+            Long userId = 1L;
+            User expectedUser = createUser();
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(expectedUser));
+
+            // when
+            User foundUser = userService.findUserById(userId);
+
+            // then
+            assertNotNull(foundUser);
+            assertEquals(expectedUser.getEmail(), foundUser.getEmail());
+            verify(userRepository).findById(userId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID로 조회 시 예외 발생")
+        void findUserById_UserNotFound() {
+            // given
+            Long userId = 999L;
+
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> userService.findUserById(userId));
+            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+            // then
+        }
+    }
+
+    @Nested
+    @DisplayName("이메일 관련 테스트")
+    class EmailVerificationTest {
+        @Test
+        @DisplayName("이메일로 사용자 조회 성공")
+        void findByEmail_Success() {
+            // given
+            String email = "test@example.com";
+            User expectedUser = createUser();
+
+            when(userRepository.findByEmail(email)).thenReturn(Optional.of(expectedUser));
+
+            // when
+            User foundUser = userService.findByEmail(email);
+
+            // then
+            assertNotNull(foundUser);
+            assertEquals(email, foundUser.getEmail());
+            verify(userRepository).findByEmail(email);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이메일로 사용자 조회 실패")
+        void findByEmail_UserNotFound() {
+            // given
+            String email = "nonexist@example.com";
+            when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> userService.findByEmail(email));
+            assertEquals(UserErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("이메일 존재 여부 확인 - 존재하는 경우")
+        void existsByEmail_True() {
+            // given
+            String email = "test@example.com";
+            when(userRepository.existsByEmail(email)).thenReturn(true);
+
+            // when
+            boolean exists = userService.existsByEmail(email);
+
+            // then
+            assertTrue(exists);
+            verify(userRepository).existsByEmail(email);
+        }
+
+        @Test
+        @DisplayName("토큰으로 사용자 조회 성공")
+        void findVerificationToken_Success() {
+            // given
+            String token = "valid-token";
+            User expectedUser = createUser();
+
+            when(userRepository.findByVerificationToken(token)).thenReturn(Optional.of(expectedUser));
+
+            // when
+            User foundUser = userService.findVerificationToken(token);
+
+            // then
+            assertNotNull(foundUser);
+            verify(userRepository).findByVerificationToken(token);
+        }
+
+        @Test
+        @DisplayName("잘못된 토큰으로 조히 시 예외 발생")
+        void findVerificationToken_InvalidToken() {
+            // given
+            String token = "invalid-token";
+
+            when(userRepository.findByVerificationToken(token)).thenReturn(Optional.empty());
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> userService.findVerificationToken(token));
+            assertEquals(AuthErrorCode.INVALID_TOKEN, exception.getErrorCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 저장 테스트")
+    class SaveUserTest {
+        @Test
+        @DisplayName("사용자 저장 성공")
+        void save_Success() {
+            // given
+            User user = createUser();
+            when(userRepository.save(any(User.class))).thenReturn(user);
+
+            // when
+            userService.save(user);
+
+            // then
+            verify(userRepository).save(user);
+        }
+    }
+
+    @Test
+    @DisplayName("중복 닉네임 확인")
+    void existsByNickname() {
+        // given
+        String existingNickname = "existingNickname";
+        String newNickname = "newNickname";
+
+        when(userRepository.existsByNickname(existingNickname)).thenReturn(true);
+        when(userRepository.existsByNickname(newNickname)).thenReturn(false);
+
+        // when
+        boolean existingResult = userService.existsByNickname(existingNickname);
+        boolean newResult = userService.existsByNickname(newNickname);
+
+        // then
+        assertTrue(existingResult);
+        assertFalse(newResult);
+        verify(userRepository).existsByNickname(existingNickname);
+        verify(userRepository).existsByNickname(newNickname);
+    }
+
+
+    private User createUser() {
+        return User.builder()
+                .email("test@example.com")
+                .password("password")
+                .role(RoleType.ROLE_USER)
+                .build();
+    }
+}

--- a/src/test/java/com/mindmate/mindmate_server/user/service/UserServiceTest.java
+++ b/src/test/java/com/mindmate/mindmate_server/user/service/UserServiceTest.java
@@ -161,26 +161,6 @@ class UserServiceTest {
         }
     }
 
-    @Test
-    @DisplayName("중복 닉네임 확인")
-    void existsByNickname() {
-        // given
-        String existingNickname = "existingNickname";
-        String newNickname = "newNickname";
-
-        when(userRepository.existsByNickname(existingNickname)).thenReturn(true);
-        when(userRepository.existsByNickname(newNickname)).thenReturn(false);
-
-        // when
-        boolean existingResult = userService.existsByNickname(existingNickname);
-        boolean newResult = userService.existsByNickname(newNickname);
-
-        // then
-        assertTrue(existingResult);
-        assertFalse(newResult);
-        verify(userRepository).existsByNickname(existingNickname);
-        verify(userRepository).existsByNickname(newNickname);
-    }
 
 
     private User createUser() {


### PR DESCRIPTION
## 🛰️ Issue Number
#26 

## 🪐 작업 내용
1. yaml 파일은 무시해주세요. tekton ci/cd 해보다가 포기한겁니다 ㅎㅎ;
2. 이메일 인증 후 jwt token 발급 받아서 profile controller에서 사용, login 시 이전 토큰 무효화
3. 테스트 코드 해보기
4. 일부 값 변경
5. user에 profile 매핑 안되어 있어서 추가